### PR TITLE
Add async compute device wrapper

### DIFF
--- a/docs/overviews/device_management_utils/DEVICE_MANAGEMENT_UTILS_OVERVIEW.md
+++ b/docs/overviews/device_management_utils/DEVICE_MANAGEMENT_UTILS_OVERVIEW.md
@@ -87,6 +87,20 @@ Each device implementation leverages hardware-specific optimizations:
 
 The MX3 implementation supports asynchronous multi-stream processing, allowing multiple inference requests to be processed concurrently.
 
+### Device-Agnostic Async Wrapper
+
+`AsyncComputeWrapper` wraps any `ComputeDevice` and exposes the same callback contract to pipelines regardless of hardware type:
+
+- `on_frame(model_path, input_data, input_data_shape, stream_idx)`: camera or pipeline code submits a preprocessed image buffer without waiting for the device implementation to finish inference. The call returns a request id that identifies the eventual result.
+- `on_result(callback)`: pipeline code registers a thread-safe result hook. The callback receives an `AsyncComputeResult` containing the request id, output data, latency, and any device exception.
+- `run(...)`: existing synchronous callers are bridged through `on_frame` and `wait_for_result`, so older pipeline code can keep the `ComputeDevice.run()` shape while new ML-heavy operations opt in to event-driven flow.
+
+The wrapper is applied by `ComputePool.add_compute_device()` by default so dynamic device lifecycle handling still uses the compute pool. `connect_streams()`, `load_model()`, `stop()`, and MX3-style `register_thread_access()` calls are forwarded to the wrapped device.
+
+Callback and device exceptions are preserved and surfaced back through the requesting operation. Object-detection operations store async callback exceptions and re-raise them on the next pipeline invocation, allowing the existing `FlowManager` and `Pipeline.record_operation_error()` path to publish centralized operation errors. The wrapper does not add retries or hardware failover; device replacement and retry policy remain compute-pool or operation-level responsibilities.
+
+The async wrapper owns a small worker thread per wrapped device. `on_frame()` queue insertion is non-blocking, result callbacks run on the wrapper worker thread, and callback registration/result state are protected by locks. Callers that share buffers across threads must treat submitted input buffers as owned by the async request until its result callback fires. `AsyncComputeResult.latency_s` captures device execution time for future latency logging.
+
 ### Error Handling
 
 Robust error handling for hardware unavailability, model loading failures, and inference execution errors.
@@ -101,6 +115,7 @@ Proper cleanup and resource management through the `stop()` method implementatio
 device_management_utils/
 ├── compute_device.py          # Abstract base class for compute devices
 ├── compute_pool.py            # Pool management for multiple devices
+├── async_compute_wrapper.py   # Device-agnostic event-driven async wrapper
 ├── cpu.py                     # CPU-based inference implementation
 ├── gpu.py                     # GPU-based inference implementation
 ├── mx3_accelerator.py         # MemryX MX3 accelerator implementation

--- a/src/main_operations/modules/object_detection/yolo_detection/implementation.py
+++ b/src/main_operations/modules/object_detection/yolo_detection/implementation.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from threading import Lock
 import traceback
-from typing import Callable, List, Optional, Dict, Any
+from typing import Callable, List, Optional, Dict, Any, cast
 from uuid import uuid4
 
 import numpy as np
@@ -212,6 +212,7 @@ class ObjectDetectionImplementation:
         try:
             from ultralytics import YOLO
 
+            assert self.model_path is not None
             self.ultralytics_model = YOLO(self.model_path)
             print(
                 f"{Colors.GREEN}Loaded YOLO model with ultralytics: {self.model_path}{Colors.RESET}"
@@ -263,7 +264,9 @@ class ObjectDetectionImplementation:
             height, width = frame.shape[:2]
             detections = []
             for r in results:
-                for box in r.boxes:
+                if r.boxes is None:
+                    continue
+                for box in cast(Any, r.boxes):
                     x1, y1, x2, y2 = box.xyxy[0].tolist()
                     score = box.conf[0].item()
                     class_id = box.cls[0].item()
@@ -284,6 +287,7 @@ class ObjectDetectionImplementation:
             if self._uses_async_device():
                 return self._run_async_device(frame)
             input_tensor = self.yolov10_ops.preprocess(frame)
+            assert self.device is not None
             outputs = self.device.run(
                 self.model_name,
                 input_tensor,

--- a/src/main_operations/modules/object_detection/yolo_detection/implementation.py
+++ b/src/main_operations/modules/object_detection/yolo_detection/implementation.py
@@ -1,9 +1,12 @@
 from pathlib import Path
+from threading import Lock
 import traceback
-from typing import List, Optional, Dict, Any
+from typing import Callable, List, Optional, Dict, Any
+from uuid import uuid4
 
 import numpy as np
 
+from src.utils.device_management_utils.async_compute_wrapper import AsyncComputeResult
 from src.utils.device_management_utils.compute_device import ComputeDevice
 from src.utils.colors import Colors
 from src.main_operations.modules.object_detection.utils.yolov10.yolov10_ops import (
@@ -61,6 +64,11 @@ class ObjectDetectionImplementation:
         self.target_height = target_height
         self.conf_threshold = conf_threshold
         self.max_detections = max_detections
+        self._async_result_lock = Lock()
+        self._latest_async_detections: List[Dict[str, Any]] = []
+        self._pending_async_request_id: str | None = None
+        self._pending_async_error: BaseException | None = None
+        self._async_unsubscribe: Callable[[], None] | None = None
 
         # Check if we should use ultralytics directly
         self._use_ultralytics = (
@@ -83,6 +91,7 @@ class ObjectDetectionImplementation:
             print(
                 f"{Colors.GREEN}Assigned stream index: {self.stream_idx}{Colors.RESET}"
             )
+        self._register_async_result_callback()
 
     def _load_model(self) -> None:
         """Load the model onto the device if available."""
@@ -91,23 +100,107 @@ class ObjectDetectionImplementation:
 
         self.model_name = Path(self.model_path).stem
 
-        try:
-            from src.utils.device_management_utils.mx3_accelerator import MX3Accelerator
+        self.device.load_model(
+            self.model_path,
+            (self.target_height, self.target_width),
+            self.post_processing_model_path,
+            self.is_grayscale,
+        )
 
-            if isinstance(self.device, MX3Accelerator):
-                self.device.load_model(
-                    self.model_path,
-                    (self.target_height, self.target_width),
-                    self.post_processing_model_path,
+    def _uses_async_device(self) -> bool:
+        """Check whether the device exposes the async callback contract.
+
+        Returns:
+            True when the current device can accept non-blocking frame requests.
+        """
+        return (
+            self.device is not None
+            and hasattr(self.device, "on_frame")
+            and hasattr(self.device, "on_result")
+            and not self._use_ultralytics
+        )
+
+    def _register_async_result_callback(self) -> None:
+        """Register the object detection result callback when available."""
+        if not self._uses_async_device() or self.device is None:
+            return
+        on_result = getattr(self.device, "on_result")
+        self._async_unsubscribe = on_result(self._handle_async_result)
+
+    def _handle_async_result(self, result: AsyncComputeResult) -> None:
+        """Handle async inference completion from a compute wrapper.
+
+        Args:
+            result: Device result payload emitted by the async wrapper.
+        """
+        with self._async_result_lock:
+            if result.request_id != self._pending_async_request_id:
+                return
+            self._pending_async_request_id = None
+
+        if result.exception is not None:
+            with self._async_result_lock:
+                self._pending_async_error = result.exception
+            return
+        if result.output_data is None:
+            with self._async_result_lock:
+                self._pending_async_error = RuntimeError(
+                    "Async object detection result did not include output data"
                 )
-            else:
-                self.device.load_model(
-                    self.model_path, (self.target_height, self.target_width)
-                )
-        except ImportError:
-            self.device.load_model(
-                self.model_path, (self.target_height, self.target_width)
+            return
+
+        try:
+            detections = self.yolov10_ops.postprocess(result.output_data)
+        except Exception as exc:
+            with self._async_result_lock:
+                self._pending_async_error = exc
+            raise
+
+        with self._async_result_lock:
+            self._latest_async_detections = detections
+
+    def _run_async_device(self, frame: np.ndarray) -> List[Dict[str, Any]]:
+        """Queue object detection inference and return the latest result.
+
+        Args:
+            frame: Input BGR frame.
+
+        Returns:
+            Latest completed detections, or an empty list before first result.
+        """
+        with self._async_result_lock:
+            pending_async_error = self._pending_async_error
+            self._pending_async_error = None
+            latest_async_detections = list(self._latest_async_detections)
+            has_pending_request = self._pending_async_request_id is not None
+
+        if pending_async_error is not None:
+            raise pending_async_error
+        if has_pending_request:
+            return latest_async_detections
+        if self.device is None:
+            raise RuntimeError("Object detection async device is not available")
+
+        input_tensor = self.yolov10_ops.preprocess(frame)
+        request_id = uuid4().hex
+        with self._async_result_lock:
+            self._pending_async_request_id = request_id
+        try:
+            on_frame = getattr(self.device, "on_frame")
+            on_frame(
+                self.model_name,
+                input_tensor,
+                (self.target_height, self.target_width),
+                self.stream_idx,
+                request_id,
             )
+        except Exception:
+            with self._async_result_lock:
+                if self._pending_async_request_id == request_id:
+                    self._pending_async_request_id = None
+            raise
+
+        return latest_async_detections
 
     def _is_onnx_or_pt_model(self, model_path: str) -> bool:
         """Check if the model file is ONNX or PyTorch format."""
@@ -188,6 +281,8 @@ class ObjectDetectionImplementation:
                     )
             return detections
         else:
+            if self._uses_async_device():
+                return self._run_async_device(frame)
             input_tensor = self.yolov10_ops.preprocess(frame)
             outputs = self.device.run(
                 self.model_name,

--- a/src/utils/device_management_utils/async_compute_wrapper.py
+++ b/src/utils/device_management_utils/async_compute_wrapper.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from queue import Empty, Full, Queue
+from threading import Event, Lock, Thread
+from time import perf_counter
+from uuid import uuid4
+
+import numpy as np
+import torch
+
+from src.utils.device_management_utils.compute_device import ComputeDevice
+
+
+@dataclass(frozen=True)
+class AsyncComputeResult:
+    """Result payload emitted by asynchronous compute wrappers."""
+
+    request_id: str
+    model_path: str
+    stream_idx: int
+    latency_s: float
+    output_data: np.ndarray | None = None
+    exception: BaseException | None = None
+    callback_exceptions: tuple[BaseException, ...] = ()
+
+
+@dataclass(frozen=True)
+class _AsyncComputeRequest:
+    """Queued compute request."""
+
+    request_id: str
+    model_path: str
+    input_data: np.ndarray | torch.Tensor
+    input_data_shape: tuple[int, int]
+    stream_idx: int
+
+
+class _AsyncComputeFuture:
+    """Thread-safe result holder for a queued compute request."""
+
+    def __init__(self) -> None:
+        """Initialize the future."""
+        self._completed = Event()
+        self._result: AsyncComputeResult | None = None
+
+    def set_result(self, result: AsyncComputeResult) -> None:
+        """Store the completed result.
+
+        Args:
+            result: Completed asynchronous compute result.
+        """
+        self._result = result
+        self._completed.set()
+
+    def result(self, timeout_s: float | None) -> AsyncComputeResult:
+        """Wait for and return the completed result.
+
+        Args:
+            timeout_s: Maximum number of seconds to wait.
+
+        Returns:
+            Completed asynchronous compute result.
+
+        Raises:
+            TimeoutError: If the result is not available before the timeout.
+        """
+        if not self._completed.wait(timeout_s):
+            raise TimeoutError("Timed out waiting for async compute result")
+        if self._result is None:
+            raise RuntimeError("Async compute result completed without payload")
+        return self._result
+
+
+class AsyncComputeWrapper(ComputeDevice):
+    """Event-driven, thread-safe wrapper around any compute device."""
+
+    def __init__(
+        self,
+        delegate: ComputeDevice,
+        max_pending_requests: int = 0,
+        result_timeout_s: float | None = None,
+    ) -> None:
+        """Initialize the async wrapper.
+
+        Args:
+            delegate: Compute device that performs the actual inference.
+            max_pending_requests: Maximum queued requests. Zero means unbounded.
+            result_timeout_s: Optional timeout used by the synchronous run bridge.
+        """
+        super().__init__(
+            device_id=delegate.device_id,
+            device_type=delegate.device_type,
+        )
+        self.delegate = delegate
+        self.result_timeout_s = result_timeout_s
+        self._request_queue: Queue[_AsyncComputeRequest | None] = Queue(
+            maxsize=max_pending_requests
+        )
+        self._callbacks: list[Callable[[AsyncComputeResult], None]] = []
+        self._callbacks_lock = Lock()
+        self._futures: dict[str, _AsyncComputeFuture] = {}
+        self._futures_lock = Lock()
+        self._stopped = Event()
+        self._worker = Thread(
+            target=self._worker_loop,
+            name=f"async-compute-{self.device_id}",
+            daemon=True,
+        )
+        self._worker.start()
+
+    def load_model(
+        self,
+        model_path: str,
+        input_data_shape: tuple[int, int],
+        post_processing_model_path: str | None = None,
+        is_grayscale: bool = False,
+    ) -> None:
+        """Load a model on the wrapped device.
+
+        Args:
+            model_path: Path to the model.
+            input_data_shape: Shape of the input data.
+            post_processing_model_path: Optional post-processing model path.
+            is_grayscale: Whether the model expects grayscale input.
+        """
+        self.delegate.load_model(
+            model_path,
+            input_data_shape,
+            post_processing_model_path,
+            is_grayscale,
+        )
+
+    def on_frame(
+        self,
+        model_path: str,
+        input_data: np.ndarray | torch.Tensor,
+        input_data_shape: tuple[int, int],
+        stream_idx: int,
+        request_id: str | None = None,
+    ) -> str:
+        """Queue a frame for device inference without blocking on execution.
+
+        Args:
+            model_path: Path or loaded model key for the target model.
+            input_data: Preprocessed model input.
+            input_data_shape: Input shape expected by the device.
+            stream_idx: Stream index for devices that support streams.
+            request_id: Optional caller-provided request id.
+
+        Returns:
+            Request id that will be included in the result callback.
+
+        Raises:
+            RuntimeError: If the wrapper has stopped or its queue is full.
+        """
+        if self._stopped.is_set():
+            raise RuntimeError(f"Async compute device {self.device_id} is stopped")
+
+        request_id = request_id or uuid4().hex
+        request = _AsyncComputeRequest(
+            request_id=request_id,
+            model_path=model_path,
+            input_data=input_data,
+            input_data_shape=input_data_shape,
+            stream_idx=stream_idx,
+        )
+        future = _AsyncComputeFuture()
+        with self._futures_lock:
+            self._futures[request_id] = future
+
+        try:
+            self._request_queue.put_nowait(request)
+        except Full as exc:
+            with self._futures_lock:
+                self._futures.pop(request_id, None)
+            raise RuntimeError(
+                f"Async compute device {self.device_id} queue is full"
+            ) from exc
+
+        return request_id
+
+    def on_result(
+        self, callback: Callable[[AsyncComputeResult], None]
+    ) -> Callable[[], None]:
+        """Register a callback for asynchronous inference results.
+
+        Args:
+            callback: Function invoked on the worker thread for every result.
+
+        Returns:
+            Function that unregisters the callback.
+        """
+        with self._callbacks_lock:
+            self._callbacks.append(callback)
+
+        def unsubscribe() -> None:
+            """Remove the registered callback."""
+            with self._callbacks_lock:
+                if callback in self._callbacks:
+                    self._callbacks.remove(callback)
+
+        return unsubscribe
+
+    def wait_for_result(
+        self, request_id: str, timeout_s: float | None = None
+    ) -> np.ndarray:
+        """Wait for a queued request to complete.
+
+        Args:
+            request_id: Request id returned by on_frame.
+            timeout_s: Maximum number of seconds to wait.
+
+        Returns:
+            Inference output.
+
+        Raises:
+            BaseException: Original device or callback exception.
+            TimeoutError: If the request does not complete in time.
+        """
+        with self._futures_lock:
+            future = self._futures.get(request_id)
+        if future is None:
+            raise KeyError(f"Unknown async compute request id: {request_id}")
+
+        result = future.result(timeout_s)
+        with self._futures_lock:
+            self._futures.pop(request_id, None)
+
+        if result.exception is not None:
+            raise result.exception
+        if result.callback_exceptions:
+            raise RuntimeError("Async compute result callback failed") from (
+                result.callback_exceptions[0]
+            )
+        if result.output_data is None:
+            raise RuntimeError("Async compute result did not include output data")
+        return result.output_data
+
+    def run(
+        self,
+        model_path: str,
+        input_data: np.ndarray | torch.Tensor,
+        input_data_shape: tuple[int, int],
+        stream_idx: int,
+    ) -> np.ndarray:
+        """Run inference through the async event contract and wait for output.
+
+        Args:
+            model_path: Path or loaded model key for the target model.
+            input_data: Preprocessed model input.
+            input_data_shape: Input shape expected by the device.
+            stream_idx: Stream index for devices that support streams.
+
+        Returns:
+            Inference output.
+        """
+        request_id = self.on_frame(
+            model_path,
+            input_data,
+            input_data_shape,
+            stream_idx,
+        )
+        return self.wait_for_result(request_id, self.result_timeout_s)
+
+    def connect_streams(self, num_streams: int) -> None:
+        """Connect streams on the wrapped device.
+
+        Args:
+            num_streams: Number of streams to connect.
+        """
+        self.delegate.connect_streams(num_streams)
+
+    def register_thread_access(self) -> int:
+        """Register stream access on devices that expose stream indexing.
+
+        Returns:
+            Stream index returned by the wrapped device.
+
+        Raises:
+            AttributeError: If the wrapped device does not support stream access.
+        """
+        register_thread_access = getattr(self.delegate, "register_thread_access")
+        return int(register_thread_access())
+
+    def stop(self) -> None:
+        """Stop the async worker and the wrapped device."""
+        self._stopped.set()
+        while True:
+            try:
+                self._request_queue.put_nowait(None)
+                break
+            except Full:
+                try:
+                    self._request_queue.get_nowait()
+                    self._request_queue.task_done()
+                except Empty:
+                    continue
+        self._worker.join()
+        self._fail_pending_requests(
+            RuntimeError(f"Async compute device {self.device_id} stopped")
+        )
+        self.delegate.stop()
+
+    def _worker_loop(self) -> None:
+        """Process queued compute requests."""
+        while True:
+            try:
+                request = self._request_queue.get(timeout=0.1)
+            except Empty:
+                if self._stopped.is_set():
+                    break
+                continue
+
+            if request is None:
+                self._request_queue.task_done()
+                break
+
+            result = self._execute_request(request)
+            self._complete_request(result)
+            self._request_queue.task_done()
+
+    def _execute_request(self, request: _AsyncComputeRequest) -> AsyncComputeResult:
+        """Execute one queued request.
+
+        Args:
+            request: Queued request payload.
+
+        Returns:
+            Async compute result.
+        """
+        start_s = perf_counter()
+        try:
+            output_data = self.delegate.run(
+                request.model_path,
+                request.input_data,
+                request.input_data_shape,
+                request.stream_idx,
+            )
+            return AsyncComputeResult(
+                request_id=request.request_id,
+                model_path=request.model_path,
+                stream_idx=request.stream_idx,
+                latency_s=perf_counter() - start_s,
+                output_data=output_data,
+            )
+        except BaseException as exc:
+            return AsyncComputeResult(
+                request_id=request.request_id,
+                model_path=request.model_path,
+                stream_idx=request.stream_idx,
+                latency_s=perf_counter() - start_s,
+                exception=exc,
+            )
+
+    def _complete_request(self, result: AsyncComputeResult) -> None:
+        """Dispatch callbacks and complete the matching future.
+
+        Args:
+            result: Result payload to dispatch.
+        """
+        callback_exceptions = self._dispatch_result_callbacks(result)
+        if callback_exceptions:
+            result = AsyncComputeResult(
+                request_id=result.request_id,
+                model_path=result.model_path,
+                stream_idx=result.stream_idx,
+                latency_s=result.latency_s,
+                output_data=result.output_data,
+                exception=result.exception,
+                callback_exceptions=tuple(callback_exceptions),
+            )
+
+        with self._futures_lock:
+            future = self._futures.get(result.request_id)
+        if future is not None:
+            future.set_result(result)
+
+    def _dispatch_result_callbacks(
+        self, result: AsyncComputeResult
+    ) -> list[BaseException]:
+        """Invoke registered result callbacks.
+
+        Args:
+            result: Result payload to emit.
+
+        Returns:
+            Exceptions raised by callbacks.
+        """
+        with self._callbacks_lock:
+            callbacks = tuple(self._callbacks)
+
+        callback_exceptions: list[BaseException] = []
+        for callback in callbacks:
+            try:
+                callback(result)
+            except BaseException as exc:
+                callback_exceptions.append(exc)
+        return callback_exceptions
+
+    def _fail_pending_requests(self, exception: BaseException) -> None:
+        """Complete pending futures with an exception.
+
+        Args:
+            exception: Exception used for unfinished requests.
+        """
+        with self._futures_lock:
+            futures = list(self._futures.values())
+            self._futures.clear()
+
+        for future in futures:
+            future.set_result(
+                AsyncComputeResult(
+                    request_id="",
+                    model_path="",
+                    stream_idx=0,
+                    latency_s=0.0,
+                    exception=exception,
+                )
+            )

--- a/src/utils/device_management_utils/compute_pool.py
+++ b/src/utils/device_management_utils/compute_pool.py
@@ -1,12 +1,18 @@
 from src.utils.device_management_utils.compute_device import ComputeDevice
+from src.utils.device_management_utils.async_compute_wrapper import AsyncComputeWrapper
 
 
 class ComputePool:
-    def __init__(self) -> None:
+    def __init__(self, enable_async_wrappers: bool = True) -> None:
         """
         Initialize the compute pool.
+
+        Args:
+            enable_async_wrappers (bool): Whether added devices should be wrapped
+                with the event-driven async compute contract.
         """
-        self.compute_pool = []
+        self.enable_async_wrappers = enable_async_wrappers
+        self.compute_pool: list[ComputeDevice] = []
         
     def add_compute_device(self, compute_device: ComputeDevice) -> None:
         """
@@ -15,7 +21,7 @@ class ComputePool:
         Args:
             compute_device (ComputeDevice): The compute device to be added.
         """
-        self.compute_pool.append(compute_device)
+        self.compute_pool.append(self._wrap_compute_device(compute_device))
         
     def remove_compute_device(self, compute_device: ComputeDevice) -> None:
         """
@@ -24,7 +30,17 @@ class ComputePool:
         Args:
             compute_device (ComputeDevice): The compute device to be removed.
         """
-        self.compute_pool.remove(compute_device)
+        if compute_device in self.compute_pool:
+            self.compute_pool.remove(compute_device)
+            return
+        for pooled_compute_device in self.compute_pool:
+            if (
+                isinstance(pooled_compute_device, AsyncComputeWrapper)
+                and pooled_compute_device.delegate is compute_device
+            ):
+                self.compute_pool.remove(pooled_compute_device)
+                return
+        raise ValueError(f"Compute device with id {compute_device.device_id} not found")
 
     def remove_compute_device_by_id(self, compute_device_id: str) -> None:
         """
@@ -72,3 +88,18 @@ class ComputePool:
         """
         for compute_device in self.compute_pool:
             compute_device.stop()
+
+    def _wrap_compute_device(self, compute_device: ComputeDevice) -> ComputeDevice:
+        """Wrap compute devices with the async event contract when enabled.
+
+        Args:
+            compute_device (ComputeDevice): Device to wrap.
+
+        Returns:
+            ComputeDevice: Wrapped or original compute device.
+        """
+        if not self.enable_async_wrappers:
+            return compute_device
+        if isinstance(compute_device, AsyncComputeWrapper):
+            return compute_device
+        return AsyncComputeWrapper(compute_device)

--- a/tests/test_system_init.py
+++ b/tests/test_system_init.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import json
+from time import sleep
+from threading import current_thread
 from pathlib import Path
 
 from typing import Any, cast
 
+import numpy as np
 import pytest
+from src.main_operations.modules.object_detection.yolo_detection.implementation import (
+    ObjectDetectionImplementation,
+)
 from src.utils.camera_utils.camera_config_manager import CameraConfigRegistry
+from src.utils.device_management_utils.async_compute_wrapper import AsyncComputeWrapper
+from src.utils.device_management_utils.compute_device import ComputeDevice
+from src.utils.device_management_utils.compute_pool import ComputePool
 from src.utils.logging.logger import Logger
 from tests.utils.dummy_dependencies import (
     DummyComputePool,
@@ -17,6 +26,115 @@ from tests.utils.dummy_dependencies import (
     FakeNetworkTable,
 )
 from tests.utils.dummy_data import dummy_frame
+
+
+class _FakeComputeDevice(ComputeDevice):
+    """Compute device used to test async wrapper behavior."""
+
+    def __init__(self, exception: BaseException | None = None) -> None:
+        """Initialize the fake compute device.
+
+        Args:
+            exception: Optional exception raised during inference.
+        """
+        super().__init__(device_id="FAKE_001", device_type="FAKE")
+        self.exception = exception
+        self.loaded_model_paths: list[str] = []
+        self.connected_streams: int | None = None
+        self.stopped = False
+        self.run_thread_names: list[str] = []
+
+    def load_model(
+        self,
+        model_path: str,
+        input_data_shape: tuple[int, int],
+        post_processing_model_path: str | None = None,
+        is_grayscale: bool = False,
+    ) -> None:
+        """Load a fake model.
+
+        Args:
+            model_path: Path to the model.
+            input_data_shape: Shape of the input data.
+            post_processing_model_path: Optional post-processing model path.
+            is_grayscale: Whether the model expects grayscale input.
+        """
+        self.loaded_model_paths.append(model_path)
+
+    def run(
+        self,
+        model_path: str,
+        input_data: np.ndarray,
+        input_data_shape: tuple[int, int],
+        stream_idx: int,
+    ) -> np.ndarray:
+        """Run fake inference.
+
+        Args:
+            model_path: Path to the model.
+            input_data: Input array.
+            input_data_shape: Shape of the input data.
+            stream_idx: Stream index.
+
+        Returns:
+            Input array incremented by one.
+        """
+        self.run_thread_names.append(current_thread().name)
+        if self.exception is not None:
+            raise self.exception
+        return input_data + 1
+
+    def connect_streams(self, num_streams: int) -> None:
+        """Connect fake streams.
+
+        Args:
+            num_streams: Number of streams to connect.
+        """
+        self.connected_streams = num_streams
+
+    def register_thread_access(self) -> int:
+        """Register fake stream access.
+
+        Returns:
+            Fake stream index.
+        """
+        return 3
+
+    def stop(self) -> None:
+        """Stop the fake compute device."""
+        self.stopped = True
+
+
+class _FakeYoloOps:
+    """YOLO ops stub for object detection async contract tests."""
+
+    def preprocess(self, frame: np.ndarray) -> np.ndarray:
+        """Preprocess a fake frame.
+
+        Args:
+            frame: Input frame.
+
+        Returns:
+            Unchanged frame.
+        """
+        return frame
+
+    def postprocess(self, outputs: np.ndarray) -> list[dict[str, Any]]:
+        """Postprocess fake model output.
+
+        Args:
+            outputs: Fake model output.
+
+        Returns:
+            Single fake detection.
+        """
+        return [
+            {
+                "bbox": (0.0, 0.0, 1.0, 1.0),
+                "score": float(outputs[0]),
+                "class_id": 1,
+            }
+        ]
 
 
 def test_pipeline_initialization_only(tmp_path: Path) -> None:
@@ -59,3 +177,102 @@ def test_pipeline_initialization_only(tmp_path: Path) -> None:
     for pipeline in pipelines.values():
         assert pipeline.operations, "Pipeline has no operations"
         assert pipeline.thread is None
+
+
+def test_compute_pool_wraps_devices_with_async_contract() -> None:
+    """Verify compute pool devices expose async callbacks and lifecycle forwarding."""
+    compute_pool = ComputePool()
+    fake_device = _FakeComputeDevice()
+
+    compute_pool.add_compute_device(fake_device)
+    wrapped_device = compute_pool.get_compute_device("FAKE_001")
+
+    assert isinstance(wrapped_device, AsyncComputeWrapper)
+    assert wrapped_device.register_thread_access() == 3
+
+    wrapped_device.load_model("model.onnx", (1, 1))
+    wrapped_device.connect_streams(2)
+    compute_pool.stop_all_devices()
+
+    assert fake_device.loaded_model_paths == ["model.onnx"]
+    assert fake_device.connected_streams == 2
+    assert fake_device.stopped
+
+
+def test_async_compute_wrapper_emits_results_from_worker_thread() -> None:
+    """Verify async requests return through on_result without caller-thread inference."""
+    fake_device = _FakeComputeDevice()
+    wrapped_device = AsyncComputeWrapper(fake_device)
+    emitted_results = []
+    wrapped_device.on_result(emitted_results.append)
+
+    request_id = wrapped_device.on_frame("model", np.array([1]), (1, 1), 0)
+    output_data = wrapped_device.wait_for_result(request_id, 1.0)
+    wrapped_device.stop()
+
+    assert output_data.tolist() == [2]
+    assert emitted_results[0].request_id == request_id
+    assert fake_device.run_thread_names[0].startswith("async-compute-")
+
+
+def test_async_compute_wrapper_surfaces_device_and_callback_exceptions() -> None:
+    """Verify worker and callback failures remain visible to pipeline callers."""
+    fake_device = _FakeComputeDevice(exception=ValueError("device failed"))
+    wrapped_device = AsyncComputeWrapper(fake_device)
+    emitted_results = []
+    wrapped_device.on_result(emitted_results.append)
+
+    request_id = wrapped_device.on_frame("model", np.array([1]), (1, 1), 0)
+    with pytest.raises(ValueError, match="device failed"):
+        wrapped_device.wait_for_result(request_id, 1.0)
+
+    assert isinstance(emitted_results[0].exception, ValueError)
+
+    callback_failure_device = AsyncComputeWrapper(_FakeComputeDevice())
+
+    def raise_callback_error(_result: Any) -> None:
+        """Raise a callback error.
+
+        Args:
+            _result: Async result payload.
+        """
+        raise RuntimeError("callback failed")
+
+    callback_failure_device.on_result(raise_callback_error)
+    callback_request_id = callback_failure_device.on_frame(
+        "model", np.array([1]), (1, 1), 0
+    )
+
+    with pytest.raises(RuntimeError, match="Async compute result callback failed"):
+        callback_failure_device.wait_for_result(callback_request_id, 1.0)
+
+    wrapped_device.stop()
+    callback_failure_device.stop()
+
+
+def test_object_detection_uses_async_device_callbacks() -> None:
+    """Verify object detection queues inference through the async contract."""
+    fake_device = _FakeComputeDevice()
+    wrapped_device = AsyncComputeWrapper(fake_device)
+    implementation = ObjectDetectionImplementation(
+        model_path="model.dfp",
+        device=wrapped_device,
+        target_width=1,
+        target_height=1,
+    )
+    implementation.yolov10_ops = _FakeYoloOps()
+
+    first_result = implementation.run(np.array([1]))
+    for _ in range(20):
+        with implementation._async_result_lock:
+            has_result = bool(implementation._latest_async_detections)
+        if has_result:
+            break
+        sleep(0.01)
+    second_result = implementation.run(np.array([1]))
+    wrapped_device.stop()
+
+    assert first_result == []
+    assert second_result == [
+        {"bbox": (0.0, 0.0, 1.0, 1.0), "score": 2.0, "class_id": 1}
+    ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a device-agnostic `AsyncComputeWrapper` with non-blocking `on_frame`, thread-safe `on_result` callbacks, synchronous `run` bridging, lifecycle forwarding, and callback exception propagation.
- Wrap compute pool devices by default so dynamic CPU/GPU/MX3 device lifecycles continue through `ComputePool` while exposing one callback contract.
- Update object detection to queue device inference through async callbacks and re-raise callback/device failures on the next pipeline run for existing `FlowManager` operation error handling.
- Document async ownership, error, retry, thread, buffer, and latency contract details in the existing device management overview.

### Testing
- `uv run pytest tests/test_system_init.py -ra` passed.
- `uv run pytest tests/ -ra` passed: 139 passed, 2 skipped.
- `uv run mypy src/utils/device_management_utils/async_compute_wrapper.py src/utils/device_management_utils/compute_pool.py src/main_operations/modules/object_detection/yolo_detection/implementation.py --ignore-missing-imports --explicit-package-bases` passed.
- `uv run mypy src/ --ignore-missing-imports --explicit-package-bases` still reports pre-existing repository type errors outside this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10d39cbd-80ec-4930-9753-d9e2fa88320e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10d39cbd-80ec-4930-9753-d9e2fa88320e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

