### PR TITLE
Add benchmark replay pipeline coverage

### DIFF
--- a/docs/overviews/webui/ASSETS_OVERVIEW.md
+++ b/docs/overviews/webui/ASSETS_OVERVIEW.md
@@ -2,7 +2,9 @@
 
 ## Directory Structure
 
-The `assets/` directory contains all static assets used by the EagleEye web interface, organized by type and purpose.
+Static assets are organized by type and purpose. Web interface assets live under
+`assets/`, while pipeline replay assets live beside the managed simulation
+videos.
 
 ```
 assets/
@@ -14,6 +16,10 @@ assets/
 ├── favicon.ico                # Browser favicon
 ├── no_image.png               # Placeholder image
 └── background.webp            # Application background
+src/utils/sim_videos/
+├── benchmark_manifest.json    # Benchmark replay metadata and thresholds
+├── *_data.csv                 # Ground-truth replay annotations
+└── *.mp4                      # Managed benchmark videos
 ```
 
 ## 3D Models (Robots)
@@ -135,6 +141,12 @@ Contains 3D models and assets for the 2025 FRC game field.
   - Optimized for web delivery
 
 ## Asset Management
+
+### Benchmark Replay Assets
+- **Location**: `src/utils/sim_videos/`
+- **Video Format**: MP4 files named after the camera bus ID, such as `basic_test.mp4`
+- **Annotations**: Ground-truth CSV files kept beside the video, such as `basic_test_data.csv`
+- **Manifest**: `benchmark_manifest.json` maps each video and annotation file to the pipeline, camera, and accuracy thresholds used by pytest replay coverage
 
 ### Loading Strategy
 - **Lazy Loading**: 3D models loaded on-demand

--- a/src/utils/sim_videos/benchmark_manifest.json
+++ b/src/utils/sim_videos/benchmark_manifest.json
@@ -1,0 +1,22 @@
+{
+    "benchmarks": [
+        {
+            "name": "basic_test_full_pipeline",
+            "pipeline_name": "test",
+            "camera_bus_id": "basic_test",
+            "video_path": "src/utils/sim_videos/basic_test.mp4",
+            "ground_truth_path": "src/utils/sim_videos/basic_test_data.csv",
+            "max_frames": 120,
+            "capture_period_us": 33333,
+            "thresholds": {
+                "translation_rmse_m": 0.25,
+                "translation_max_error_m": 0.5,
+                "yaw_rmse_rad": 0.2,
+                "yaw_max_error_rad": 0.35,
+                "timestamp_max_drift_us": 0,
+                "min_pose_samples": 10,
+                "min_apriltag_detection_frames": 10
+            }
+        }
+    ]
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,6 +12,8 @@ executing the full pipeline end-to-end.
 - Initializes each operation with config defaults and dummy dependencies.
 - Calls `run()` with operation-specific dummy inputs.
 - Initializes pipelines without starting any threads or camera access.
+- Loads benchmark replay metadata from `src/utils/sim_videos/benchmark_manifest.json`
+  and replays available MP4 assets through the configured full pipeline.
 
 ## Running tests
 
@@ -30,6 +32,14 @@ pytest -q tests
 | `EAGLEEYE_TEST_APRILTAG_MAP_PATH` | AprilTag map file | `files/apriltag_map_path/frc2025r2.json` |
 | `EAGLEEYE_TEST_CAMERA_NAME` | Device input camera name | `test_camera` |
 | `EAGLEEYE_TEST_NETWORK_TABLE_KEY` | NetworkTables key | `test_key` |
+
+## Benchmark replay assets
+
+Full-pipeline replay tests consume versioned assets from `src/utils/sim_videos/`.
+Each benchmark entry declares the MP4 video, ground-truth CSV, pipeline name,
+camera bus ID, and pose/detection/timing thresholds. When a large benchmark MP4
+is not checked out in the local environment, pytest reports a `hardware_skip`
+instead of failing unrelated smoke tests.
 
 ## Notes
 

--- a/tests/test_system_init.py
+++ b/tests/test_system_init.py
@@ -2,21 +2,37 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import math
 from pathlib import Path
 
 from typing import Any, cast
 
+import numpy as np
 import pytest
 from src.utils.camera_utils.camera_config_manager import CameraConfigRegistry
 from src.utils.logging.logger import Logger
+from src.utils.timing import get_timing, unwrap_timed_deep
 from tests.utils.dummy_dependencies import (
     DummyComputePool,
     FakeCameraThreadManager,
     FakeEagleEyeInterface,
     FakeNetworkTable,
+    ReplayCameraThreadManager,
 )
-from tests.utils.dummy_data import dummy_frame
+from tests.utils.dummy_data import (
+    BenchmarkGroundTruthFrame,
+    dummy_frame,
+    load_benchmark_ground_truth_csv,
+)
+
+
+BENCHMARK_MANIFEST_RELATIVE_PATH = Path(
+    "src/utils/sim_videos/benchmark_manifest.json"
+)
+SIM_VIDEO_RELATIVE_DIRECTORY = Path("src/utils/sim_videos")
+DEFAULT_CAPTURE_PERIOD_US = 33_333
 
 
 def test_pipeline_initialization_only(tmp_path: Path) -> None:
@@ -59,3 +75,347 @@ def test_pipeline_initialization_only(tmp_path: Path) -> None:
     for pipeline in pipelines.values():
         assert pipeline.operations, "Pipeline has no operations"
         assert pipeline.thread is None
+
+
+def _project_root() -> Path:
+    """Resolve the repository root for benchmark assets.
+
+    Returns:
+        Path: Repository root.
+    """
+
+    return Path(__file__).resolve().parents[1]
+
+
+def _load_benchmark_specs(project_root: Path) -> list[dict[str, Any]]:
+    """Load benchmark replay specifications from the asset manifest.
+
+    Args:
+        project_root: Repository root.
+
+    Returns:
+        List of benchmark replay specifications.
+    """
+
+    manifest_path = project_root / BENCHMARK_MANIFEST_RELATIVE_PATH
+    with manifest_path.open("r", encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
+
+    benchmarks = manifest.get("benchmarks", [])
+    assert isinstance(benchmarks, list), "Benchmark manifest must contain a list"
+    return cast(list[dict[str, Any]], benchmarks)
+
+
+def _resolve_benchmark_asset_path(
+    project_root: Path,
+    relative_path_text: str,
+    expected_suffix: str,
+) -> Path:
+    """Resolve and validate a benchmark asset path.
+
+    Args:
+        project_root: Repository root.
+        relative_path_text: Project-relative asset path from the manifest.
+        expected_suffix: Required file suffix.
+
+    Returns:
+        Path: Resolved asset path.
+    """
+
+    relative_path = Path(relative_path_text)
+    assert not relative_path.is_absolute(), f"{relative_path_text} must be relative"
+    assert (
+        relative_path.suffix == expected_suffix
+    ), f"{relative_path_text} must end with {expected_suffix}"
+
+    asset_path = (project_root / relative_path).resolve()
+    benchmark_directory = (project_root / SIM_VIDEO_RELATIVE_DIRECTORY).resolve()
+    assert asset_path.is_relative_to(
+        benchmark_directory
+    ), f"{relative_path_text} must stay under {SIM_VIDEO_RELATIVE_DIRECTORY}"
+    return asset_path
+
+
+def test_benchmark_manifest_points_to_managed_assets() -> None:
+    """Verify benchmark replay metadata uses the managed static asset layout."""
+
+    project_root = _project_root()
+    benchmark_specs = _load_benchmark_specs(project_root)
+    assert benchmark_specs, "At least one benchmark replay spec is required"
+
+    for benchmark_spec in benchmark_specs:
+        video_path = _resolve_benchmark_asset_path(
+            project_root,
+            str(benchmark_spec["video_path"]),
+            ".mp4",
+        )
+        ground_truth_path = _resolve_benchmark_asset_path(
+            project_root,
+            str(benchmark_spec["ground_truth_path"]),
+            ".csv",
+        )
+        thresholds = benchmark_spec["thresholds"]
+
+        assert video_path.name == f"{benchmark_spec['camera_bus_id']}.mp4"
+        assert ground_truth_path.exists(), f"{ground_truth_path} is missing"
+        assert thresholds["translation_rmse_m"] > 0
+        assert thresholds["translation_max_error_m"] > 0
+        assert thresholds["yaw_rmse_rad"] > 0
+        assert thresholds["yaw_max_error_rad"] > 0
+        assert thresholds["timestamp_max_drift_us"] >= 0
+        assert thresholds["min_pose_samples"] > 0
+        assert thresholds["min_apriltag_detection_frames"] >= 0
+
+
+def _require_replay_dependencies() -> None:
+    """Skip benchmark replay when native video or AprilTag dependencies are absent."""
+
+    for module_name in ("cv2", "pupil_apriltags"):
+        if importlib.util.find_spec(module_name) is None:
+            pytest.skip(f"hardware_skip: {module_name} is unavailable")
+
+
+def _decode_video_frames(video_path: Path, max_frames: int) -> list[np.ndarray]:
+    """Decode benchmark video frames with OpenCV.
+
+    Args:
+        video_path: MP4 benchmark video path.
+        max_frames: Maximum number of frames to decode.
+
+    Returns:
+        List of decoded BGR frames.
+    """
+
+    import cv2
+
+    capture = cv2.VideoCapture(str(video_path))
+    if not capture.isOpened():
+        pytest.skip(f"hardware_skip: {video_path.name} could not be opened")
+
+    frames: list[np.ndarray] = []
+    while len(frames) < max_frames:
+        success, frame = capture.read()
+        if not success:
+            break
+        frames.append(frame)
+    capture.release()
+
+    if not frames:
+        pytest.skip(f"hardware_skip: {video_path.name} has no decodable frames")
+    return frames
+
+
+def _pose_yaw_rad(pose_matrix: np.ndarray) -> float:
+    """Calculate planar yaw from a 4x4 pose matrix.
+
+    Args:
+        pose_matrix: Robot pose transform.
+
+    Returns:
+        float: Planar yaw in radians.
+    """
+
+    return float(math.atan2(float(pose_matrix[1, 0]), float(pose_matrix[0, 0])))
+
+
+def _wrapped_angle_error_rad(actual_yaw: float, expected_yaw: float) -> float:
+    """Calculate wrapped absolute yaw error.
+
+    Args:
+        actual_yaw: Measured yaw in radians.
+        expected_yaw: Expected yaw in radians.
+
+    Returns:
+        float: Absolute wrapped angle error in radians.
+    """
+
+    yaw_delta = actual_yaw - expected_yaw
+    return abs(math.atan2(math.sin(yaw_delta), math.cos(yaw_delta)))
+
+
+def _get_operation_output(pipeline: Any, operation_name: str) -> Any:
+    """Fetch the latest pipeline output for an operation name.
+
+    Args:
+        pipeline: Pipeline instance under test.
+        operation_name: Operation action name without the .py suffix.
+
+    Returns:
+        Any: Latest operation output, or None when unavailable.
+    """
+
+    for operation_uuid, operation in pipeline.operations.items():
+        if operation.name == operation_name:
+            return pipeline.flow_manager.operation_outputs.get(operation_uuid)
+    return None
+
+
+def _get_detection_count(pipeline: Any) -> int:
+    """Count AprilTag detections from the latest replay frame.
+
+    Args:
+        pipeline: Pipeline instance under test.
+
+    Returns:
+        int: Number of AprilTag detections.
+    """
+
+    detections = unwrap_timed_deep(_get_operation_output(pipeline, "detect_apriltags"))
+    return len(detections) if isinstance(detections, list) else 0
+
+
+def _compare_pose_to_ground_truth(
+    pose_matrix: np.ndarray,
+    expected_pose: BenchmarkGroundTruthFrame,
+) -> tuple[float, float]:
+    """Compare a measured robot pose with ground truth.
+
+    Args:
+        pose_matrix: Measured 4x4 robot pose transform.
+        expected_pose: Expected pose annotation.
+
+    Returns:
+        tuple[float, float]: Translation and yaw errors.
+    """
+
+    measured_translation: np.ndarray = pose_matrix[:3, 3].astype(float)
+    expected_translation: np.ndarray = np.array(
+        [expected_pose.x, expected_pose.y, expected_pose.z],
+        dtype=float,
+    )
+    translation_error = float(
+        np.linalg.norm(measured_translation - expected_translation)
+    )
+    yaw_error = _wrapped_angle_error_rad(
+        _pose_yaw_rad(pose_matrix),
+        expected_pose.yaw_rad,
+    )
+    return translation_error, yaw_error
+
+
+def _run_benchmark_replay(
+    benchmark_spec: dict[str, Any],
+    project_root: Path,
+) -> bool:
+    """Replay one benchmark video through the configured full pipeline.
+
+    Args:
+        benchmark_spec: Benchmark replay specification.
+        project_root: Repository root.
+
+    Returns:
+        bool: True when the benchmark ran, False when its video is absent.
+    """
+
+    video_path = _resolve_benchmark_asset_path(
+        project_root,
+        str(benchmark_spec["video_path"]),
+        ".mp4",
+    )
+    if not video_path.exists():
+        return False
+
+    _require_replay_dependencies()
+    ground_truth_path = _resolve_benchmark_asset_path(
+        project_root,
+        str(benchmark_spec["ground_truth_path"]),
+        ".csv",
+    )
+    ground_truth_by_frame = load_benchmark_ground_truth_csv(ground_truth_path)
+    thresholds = benchmark_spec["thresholds"]
+    max_frames = int(benchmark_spec.get("max_frames", len(ground_truth_by_frame)))
+    frames = _decode_video_frames(video_path, max_frames)
+
+    web_interface = FakeEagleEyeInterface()
+    network_table = FakeNetworkTable()
+    compute_pool = DummyComputePool()
+    logger = Logger(log_directory="logs/test")
+    camera_manager = ReplayCameraThreadManager(
+        camera_name=str(benchmark_spec["camera_bus_id"]),
+        frames=frames,
+        capture_period_us=int(
+            benchmark_spec.get("capture_period_us", DEFAULT_CAPTURE_PERIOD_US)
+        ),
+    )
+    camera_config_registry = CameraConfigRegistry()
+
+    from src.config.utils.generate_all_pipelines import generate_all_pipelines
+
+    pipelines = generate_all_pipelines(
+        cast(Any, web_interface),
+        cast(Any, compute_pool),
+        cast(Any, network_table),
+        cast(Any, camera_manager),
+        camera_config_registry=camera_config_registry,
+        logger=logger,
+        pipeline_config=str(project_root / "src" / "config" / "pipeline_config.json"),
+    )
+    pipeline = pipelines[str(benchmark_spec["pipeline_name"])]
+
+    translation_errors: list[float] = []
+    yaw_errors: list[float] = []
+    timestamp_drifts_us: list[int] = []
+    apriltag_detection_frames = 0
+
+    for frame_index in range(len(frames)):
+        if frame_index not in ground_truth_by_frame:
+            continue
+
+        camera_manager.advance_to_frame(frame_index)
+        previous_pose_count = len(web_interface.robot_positions)
+        pipeline.run()
+
+        if _get_detection_count(pipeline) > 0:
+            apriltag_detection_frames += 1
+
+        if len(web_interface.robot_positions) == previous_pose_count:
+            continue
+
+        latest_pose = np.asarray(web_interface.robot_positions[-1], dtype=float)
+        translation_error, yaw_error = _compare_pose_to_ground_truth(
+            latest_pose,
+            ground_truth_by_frame[frame_index],
+        )
+        translation_errors.append(translation_error)
+        yaw_errors.append(yaw_error)
+
+        robot_pose_output = _get_operation_output(pipeline, "robot_pose_output")
+        timing = get_timing(robot_pose_output)
+        if timing is not None:
+            expected_capture_nt_us = frame_index * camera_manager.capture_period_us
+            timestamp_drifts_us.append(
+                abs(timing.capture_nt_us - expected_capture_nt_us)
+            )
+
+    assert len(translation_errors) >= thresholds["min_pose_samples"]
+    assert apriltag_detection_frames >= thresholds["min_apriltag_detection_frames"]
+    assert max(timestamp_drifts_us, default=0) <= thresholds["timestamp_max_drift_us"]
+    assert max(translation_errors) <= thresholds["translation_max_error_m"]
+    assert math.sqrt(float(np.mean(np.square(translation_errors)))) <= thresholds[
+        "translation_rmse_m"
+    ]
+    assert max(yaw_errors) <= thresholds["yaw_max_error_rad"]
+    assert math.sqrt(float(np.mean(np.square(yaw_errors)))) <= thresholds[
+        "yaw_rmse_rad"
+    ]
+    return True
+
+
+def test_benchmark_videos_replay_full_pipeline_against_ground_truth() -> None:
+    """Replay available benchmark videos and enforce configured error margins."""
+
+    project_root = _project_root()
+    ran_benchmark = False
+    missing_video_names: list[str] = []
+
+    for benchmark_spec in _load_benchmark_specs(project_root):
+        if _run_benchmark_replay(benchmark_spec, project_root):
+            ran_benchmark = True
+        else:
+            missing_video_names.append(str(benchmark_spec["video_path"]))
+
+    if not ran_benchmark:
+        pytest.skip(
+            "hardware_skip: benchmark video assets are unavailable: "
+            + ", ".join(missing_video_names)
+        )

--- a/tests/utils/dummy_data.py
+++ b/tests/utils/dummy_data.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import csv
 from dataclasses import dataclass
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
@@ -15,6 +17,47 @@ class DummyApriltagDetection:
 
     tag_id: int
     corners: np.ndarray
+
+
+@dataclass(frozen=True)
+class BenchmarkGroundTruthFrame:
+    """Ground-truth pose data for one benchmark replay frame."""
+
+    frame_index: int
+    x: float
+    y: float
+    z: float
+    yaw_rad: float
+    pitch_rad: float
+
+
+def load_benchmark_ground_truth_csv(
+    ground_truth_path: Path,
+) -> dict[int, BenchmarkGroundTruthFrame]:
+    """Load benchmark pose annotations keyed by frame index.
+
+    Args:
+        ground_truth_path: CSV file containing rendered benchmark annotations.
+
+    Returns:
+        Mapping of frame index to benchmark ground-truth pose values.
+    """
+
+    frame_ground_truth: dict[int, BenchmarkGroundTruthFrame] = {}
+    with ground_truth_path.open("r", encoding="utf-8", newline="") as csv_file:
+        reader = csv.DictReader(csv_file)
+        for row in reader:
+            frame_index = int(row["frame"])
+            frame_ground_truth[frame_index] = BenchmarkGroundTruthFrame(
+                frame_index=frame_index,
+                x=float(row["x"]),
+                y=float(row["y"]),
+                z=float(row["z"]),
+                yaw_rad=float(row["yaw_rad"]),
+                pitch_rad=float(row.get("pitch_rad", 0.0)),
+            )
+
+    return frame_ground_truth
 
 
 def dummy_frame() -> np.ndarray:

--- a/tests/utils/dummy_dependencies.py
+++ b/tests/utils/dummy_dependencies.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 import numpy as np
 
@@ -419,3 +419,52 @@ class FakeCameraThreadManager:
         Returns:
             list[str]: Result of get all bus ids."""
         return list(self.bus_id_to_name.keys())
+
+
+class ReplayCameraThreadManager(FakeCameraThreadManager):
+    """Camera manager that advances through decoded benchmark frames."""
+
+    def __init__(
+        self,
+        camera_name: str,
+        frames: Sequence[np.ndarray],
+        capture_period_us: int,
+    ) -> None:
+        """Initialize replay frames for one benchmark camera.
+
+        Args:
+            camera_name: Camera and bus ID used by the pipeline config.
+            frames: Ordered decoded video frames.
+            capture_period_us: Synthetic capture timestamp period.
+        """
+
+        if not frames:
+            raise ValueError("ReplayCameraThreadManager requires at least one frame")
+
+        self.camera_name = camera_name
+        self.frames = list(frames)
+        self.capture_period_us = capture_period_us
+        super().__init__(default_frame=self.frames[0])
+        self.add_camera(camera_name, self.frames[0])
+        self.register_bus_id(camera_name, camera_name)
+
+    def advance_to_frame(self, frame_index: int) -> None:
+        """Move the replay camera to a decoded frame index.
+
+        Args:
+            frame_index: Zero-based frame index to expose to the pipeline.
+        """
+
+        worker = self.camera_objects[self.camera_name]
+        worker.frame = self.frames[frame_index]
+        worker.capture_nt_us = frame_index * self.capture_period_us
+
+    @property
+    def frame_count(self) -> int:
+        """Return the number of decoded replay frames.
+
+        Returns:
+            int: Number of decoded frames.
+        """
+
+        return len(self.frames)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a benchmark replay manifest under `src/utils/sim_videos/` for the existing `basic_test` annotations and configurable pose, detection, and timing thresholds.
- Extend `tests/test_system_init.py` with manifest validation plus a full-pipeline replay runner that decodes available MP4 benchmarks, feeds frames through the configured pipeline, and asserts output drift against ground truth.
- Add replay camera and CSV ground-truth helpers, and document benchmark asset placement in the existing test and asset docs.

### Testing
- `uv run pytest tests/test_system_init.py -ra` — passes with the replay test skipped when `basic_test.mp4` is absent.
- `uv run pytest tests/ -ra` — 136 passed, 3 skipped.
- `uv run mypy tests/test_system_init.py tests/utils/dummy_data.py tests/utils/dummy_dependencies.py --ignore-missing-imports --explicit-package-bases --follow-imports=skip` — passes.
- `uv run mypy src/ --ignore-missing-imports --explicit-package-bases` — reports pre-existing `src/` type errors unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a35853b-83fa-4970-a205-d5792ba1a6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a35853b-83fa-4970-a205-d5792ba1a6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

