### PR TITLE
Remove PnP position cache and jump retry

### DIFF
--- a/docs/md_docs/pipeline_docs/PipelineOverview.md
+++ b/docs/md_docs/pipeline_docs/PipelineOverview.md
@@ -77,8 +77,7 @@ Pipelines are instantiated by reading the pipeline config in `generate_all_pipel
             "action_name": "pnp_camera_localization.py",
             "action_params": {
                 "camera_parameters_path": "/path/to/camera_parameters.json",
-                "apriltag_map_path": "/path/to/apriltag_map.json",
-                "jump_threshold": 2
+                "apriltag_map_path": "/path/to/apriltag_map.json"
             },
             "position": {
                 "x": 700,

--- a/docs/md_docs/pipeline_docs/PipelineOverview.md
+++ b/docs/md_docs/pipeline_docs/PipelineOverview.md
@@ -76,7 +76,7 @@ Pipelines are instantiated by reading the pipeline config in `generate_all_pipel
         {
             "action_name": "pnp_camera_localization.py",
             "action_params": {
-                "camera_parameters_path": "/path/to/camera_parameters.json",
+                "camera_bus_id": "front_cam",
                 "apriltag_map_path": "/path/to/apriltag_map.json"
             },
             "position": {

--- a/docs/md_docs/pipeline_docs/main_operations/PnpCameraLocalization.md
+++ b/docs/md_docs/pipeline_docs/main_operations/PnpCameraLocalization.md
@@ -10,7 +10,7 @@
 - Output: a 4×4 homogeneous `numpy.ndarray` representing `T_field_from_camera`, or `None` when pose estimation fails.
 - Translation is in meters. The rotation is a 3×3 matrix.
 
-For each mapped detection, the solver uses the tag's four field-space corners and detected image-space corners, then calls OpenCV `solvePnP(..., SOLVEPNP_ITERATIVE)`. It inverts the resulting camera-space transform before returning the field-from-camera transform.
+For each mapped detection, the solver uses the tag's four field-space corners and detected image-space corners, then calls OpenCV `solvePnP(..., SOLVEPNP_ITERATIVE)`. It inverts the resulting camera-space transform before returning the field-from-camera transform. Each frame is solved independently from the current detections only.
 
 The fmap parser converts tag sizes from millimeters to meters. The field map and camera calibration must use the expected field coordinate convention; validate the final published pose on the robot.
 
@@ -20,7 +20,6 @@ The fmap parser converts tag sizes from millimeters to meters. The field map and
 | --- | --- | --- | --- |
 | `camera_bus_id` | `str` | required | Resolves the camera configuration and its intrinsics file. |
 | `apriltag_map_path` | `str` | required | Path to the AprilTag field-map JSON/fmap file. |
-| `jump_threshold` | `float` | `2.0` | Position jump threshold in meters used when retrying a solve without the cached guess. |
 
 `camera_config_registry` is injected by the pipeline runtime. The operation loads `intrinsics_path` from the configuration for `camera_bus_id`; `camera_parameters_path` is not an action parameter.
 
@@ -29,8 +28,7 @@ The fmap parser converts tag sizes from millimeters to meters. The field map and
   "action_name": "pnp_camera_localization.py",
   "action_params": {
     "camera_bus_id": "basic_test",
-    "apriltag_map_path": "{project_root}/files/apriltag_map_path/frc2025r2.json",
-    "jump_threshold": 2.0
+    "apriltag_map_path": "{project_root}/files/apriltag_map_path/frc2025r2.json"
   }
 }
 ```
@@ -42,7 +40,6 @@ This operation returns a raw matrix, but the pipeline runtime propagates the cap
 ## Limitations
 
 - No reprojection error, tag IDs/count, ambiguity, covariance, or solve-status value is emitted with the matrix.
-- The solver has a cached pose guess and jump retry, but it is not a full pose filter.
 - Timestamp propagation labels the source frame; it does not make the PnP result a hardware-exposure-time measurement.
 
 ## Files

--- a/src/config/pipeline_config.json
+++ b/src/config/pipeline_config.json
@@ -53,8 +53,7 @@
             "action_name": "pnp_camera_localization.py",
             "action_params": {
                 "camera_bus_id": "basic_test",
-                "apriltag_map_path": "{project_root}/files/apriltag_map_path/frc2025r2.json",
-                "jump_threshold": 2
+                "apriltag_map_path": "{project_root}/files/apriltag_map_path/frc2025r2.json"
             },
             "position": {
                 "x": 860,

--- a/src/main_operations/definitions/config_data/pnp_camera_localization_config_def.json
+++ b/src/main_operations/definitions/config_data/pnp_camera_localization_config_def.json
@@ -25,22 +25,6 @@
             "default": "{project_root}/config/apriltag_map.fmap",
             "required": true,
             "restart_for_change": true
-        },
-        "jump_threshold": {
-            "type": "float",
-            "description": "Maximum distance threshold in meters for pose jumps. Poses beyond this threshold trigger cache clearing",
-            "default": 2.0,
-            "required": false,
-            "restart_for_change": false,
-            "min": 0.1,
-            "max": 10.0
-        },
-        "position_cache_enabled": {
-            "type": "bool",
-            "description": "Reuse the previous position as an initial guess. When disabled, each position is computed only from the current detections.",
-            "default": true,
-            "required": false,
-            "restart_for_change": true
         }
     }
 }

--- a/src/main_operations/definitions/pnp_camera_localization.py
+++ b/src/main_operations/definitions/pnp_camera_localization.py
@@ -20,8 +20,6 @@ class PnpCameraLocalizationDefinition(OperationInstance):
         self,
         camera_bus_id: str,
         apriltag_map_path: str,
-        jump_threshold: float = 2.0,
-        position_cache_enabled: bool = True,
         camera_config_registry: CameraConfigRegistry | None = None,
         web_interface: EagleEyeInterface | None = None,
         compute_pool: ComputePool | None = None,
@@ -31,9 +29,6 @@ class PnpCameraLocalizationDefinition(OperationInstance):
         Args:
             camera_bus_id: Camera bus ID used to resolve calibration files.
             apriltag_map_path: Path to the apriltag map file.
-            jump_threshold: Maximum distance threshold in meters for pose jumps.
-            position_cache_enabled: Whether to reuse the previous pose as an
-                extrinsic guess for subsequent estimates.
             camera_config_registry: Injected shared camera config registry.
         """
         self.web_interface = web_interface
@@ -66,8 +61,6 @@ class PnpCameraLocalizationDefinition(OperationInstance):
             camera_matrix=camera_matrix,
             distortion_coefficients=distortion_coefficients,
             apriltag_map=apriltag_map,
-            jump_threshold=jump_threshold,
-            position_cache_enabled=position_cache_enabled,
         )
 
     def run(self, detections: List[Detection]) -> Optional[np.ndarray]:

--- a/src/main_operations/modules/apriltags/pnp_localization.py
+++ b/src/main_operations/modules/apriltags/pnp_localization.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional
+
 import cv2
 import numpy as np
 from pupil_apriltags import Detection
@@ -19,50 +20,30 @@ class PnpLocalization:
         camera_matrix: np.ndarray,
         distortion_coefficients: np.ndarray,
         apriltag_map: Dict[int, Apriltag],
-        jump_threshold: float = 2.0,
-        position_cache_enabled: bool = True,
     ) -> None:
         """Initialize the AprilTag pose estimator.
 
         Args:
-            camera_matrix (np.ndarray): Camera intrinsic matrix.
-            distortion_coefficients (np.ndarray): Camera distortion coefficients.
-            apriltag_map (Dict[int, Apriltag]): Mapping of tag IDs to AprilTag objects.
-            jump_threshold (float): Maximum distance threshold in meters for pose jumps.
-                                   Poses beyond this threshold trigger cache clearing.
-            position_cache_enabled (bool): Whether prior poses may be used as an
-                extrinsic guess for subsequent pose estimates.
+            camera_matrix: Camera intrinsic matrix.
+            distortion_coefficients: Camera distortion coefficients.
+            apriltag_map: Mapping of tag IDs to AprilTag objects.
         """
         self.camera_matrix = camera_matrix.astype(np.float32, copy=False)
         dist = distortion_coefficients.astype(np.float32, copy=False)
         if dist.ndim == 1 or (dist.ndim == 2 and dist.shape[0] == 1):
             dist = dist.reshape((-1, 1))
         self.distortion_coefficients = dist
-
         self.apriltag_map = apriltag_map
-        self.jump_threshold = jump_threshold
-        self.position_cache_enabled = position_cache_enabled
-        self.last_pose = None
-        self._last_camera_space_pose = None
-        self._last_rvec = None
-        self.non_finite_count = 0
-
-    def clear_position_cache(self) -> None:
-        """Clear the position cache and reset non-finite counter."""
-        self.last_pose = None
-        self._last_camera_space_pose = None
-        self._last_rvec = None
-        self.non_finite_count = 0
 
     @staticmethod
     def fast_se3_inverse(t: np.ndarray) -> np.ndarray:
         """Fast analytical inverse for SE(3) transformation matrix.
 
         Args:
-            t (np.ndarray): 4x4 SE(3) transformation matrix.
+            t: 4x4 SE(3) transformation matrix.
 
         Returns:
-            np.ndarray: 4x4 inverse transformation matrix.
+            4x4 inverse transformation matrix.
         """
         R = t[:3, :3]
         translation = t[:3, 3]
@@ -79,13 +60,13 @@ class PnpLocalization:
         return t_inv_matrix
 
     def _fast_rodrigues(self, rvec: np.ndarray) -> np.ndarray:
-        """Compute rotation matrix from rotation vector using Rodrigues formula in NumPy.
+        """Compute rotation matrix from rotation vector using Rodrigues formula.
 
         Args:
-            rvec (np.ndarray): Rotation vector (3, ) or (3, 1).
+            rvec: Rotation vector (3,) or (3, 1).
 
         Returns:
-            np.ndarray: Rotation matrix (3, 3) as float32.
+            Rotation matrix (3, 3) as float32.
         """
         v = rvec.reshape(3).astype(np.float32, copy=False)
         theta = float(np.linalg.norm(v))
@@ -108,11 +89,11 @@ class PnpLocalization:
         """Estimate camera pose from AprilTag detections.
 
         Args:
-            detections (List[Detection]): List of AprilTag detections.
+            detections: List of AprilTag detections.
 
         Returns:
-            Optional[np.ndarray]: 4x4 transformation matrix representing camera pose,
-                                or None if pose estimation failed.
+            4x4 transformation matrix representing camera pose in field
+            coordinates, or None if pose estimation failed.
         """
         image_points_list = []
         object_points_list = []
@@ -147,140 +128,38 @@ class PnpLocalization:
         ):
             return None
 
-        success = False
-        rotation_vector = None
-        translation_vector = None
-
-        # First attempt with extrinsic guess if available
-        use_guess = (
-            self.position_cache_enabled
-            and self._last_camera_space_pose is not None
-            and self._last_rvec is not None
-            and np.all(np.isfinite(self._last_camera_space_pose))
-            and np.all(np.isfinite(self._last_rvec))
+        success, rotation_vector, translation_vector = cv2.solvePnP(
+            object_points,
+            image_points,
+            self.camera_matrix,
+            self.distortion_coefficients,
+            flags=cv2.SOLVEPNP_ITERATIVE,
         )
 
-        if use_guess:
-            last_t = (
-                self._last_camera_space_pose[:3, 3]
-                if self._last_camera_space_pose is not None
-                else None
-            )
-            if last_t is None:
-                success, rotation_vector, translation_vector = cv2.solvePnP(
-                    object_points,
-                    image_points,
-                    self.camera_matrix,
-                    self.distortion_coefficients,
-                    flags=cv2.SOLVEPNP_ITERATIVE,
-                )
-            success, rotation_vector, translation_vector = cv2.solvePnP(
-                object_points,
-                image_points,
-                self.camera_matrix,
-                self.distortion_coefficients,
-                rvec=self._last_rvec,
-                tvec=last_t.reshape(3, 1).astype(np.float32, copy=False),
-                useExtrinsicGuess=True,
-                flags=cv2.SOLVEPNP_ITERATIVE,
-            )
-        else:
-            success, rotation_vector, translation_vector = cv2.solvePnP(
-                object_points,
-                image_points,
-                self.camera_matrix,
-                self.distortion_coefficients,
-                flags=cv2.SOLVEPNP_ITERATIVE,
-            )
-
-        camera_space_transform = None
-        if success and rotation_vector is not None and translation_vector is not None:
-            if not (
-                np.all(np.isfinite(rotation_vector))
-                and np.all(np.isfinite(translation_vector))
-            ):
-                return None
-            rotation_matrix = self._fast_rodrigues(rotation_vector)
-            camera_space_transform = np.eye(4, dtype=np.float32)
-            camera_space_transform[:3, :3] = rotation_matrix
-            camera_space_transform[:3, 3] = translation_vector.flatten().astype(
-                np.float32, copy=False
-            )
-            if self.position_cache_enabled and np.all(np.isfinite(rotation_vector)):
-                self._last_rvec = rotation_vector.astype(np.float32, copy=False)
-
-        if camera_space_transform is None:
+        if (
+            not success
+            or rotation_vector is None
+            or translation_vector is None
+            or not np.all(np.isfinite(rotation_vector))
+            or not np.all(np.isfinite(translation_vector))
+        ):
             return None
+
+        rotation_matrix = self._fast_rodrigues(rotation_vector)
+        camera_space_transform = np.eye(4, dtype=np.float32)
+        camera_space_transform[:3, :3] = rotation_matrix
+        camera_space_transform[:3, 3] = translation_vector.flatten().astype(
+            np.float32, copy=False
+        )
 
         global_camera_transform = PnpLocalization.fast_se3_inverse(
             camera_space_transform
         )
 
-        # Check if pose is far from previous pose (> 2m)
-        if (
-            self.last_pose is not None
-            and np.all(np.isfinite(global_camera_transform))
-            and np.all(np.isfinite(self.last_pose))
-            and use_guess
-        ):
-            distance = np.linalg.norm(
-                global_camera_transform[:3, 3] - self.last_pose[:3, 3]
-            )
-            if distance > self.jump_threshold:
-                # Clear cache and recompute without extrinsic guess
-                self.clear_position_cache()
-
-                success, rotation_vector, translation_vector = cv2.solvePnP(
-                    object_points,
-                    image_points,
-                    self.camera_matrix,
-                    self.distortion_coefficients,
-                    flags=cv2.SOLVEPNP_ITERATIVE,
-                )
-
-                if (
-                    success
-                    and rotation_vector is not None
-                    and translation_vector is not None
-                ):
-                    if not (
-                        np.all(np.isfinite(rotation_vector))
-                        and np.all(np.isfinite(translation_vector))
-                    ):
-                        return None
-                    rotation_matrix = self._fast_rodrigues(rotation_vector)
-                    camera_space_transform = np.eye(4, dtype=np.float32)
-                    camera_space_transform[:3, :3] = rotation_matrix
-                    camera_space_transform[:3, 3] = translation_vector.flatten().astype(
-                        np.float32, copy=False
-                    )
-                    if self.position_cache_enabled and np.all(np.isfinite(rotation_vector)):
-                        self._last_rvec = rotation_vector.astype(np.float32, copy=False)
-
-                    global_camera_transform = PnpLocalization.fast_se3_inverse(
-                        camera_space_transform
-                    )
-
-        if self.position_cache_enabled and np.all(
-            np.isfinite(camera_space_transform)
-        ):
-            self._last_camera_space_pose = camera_space_transform
-
         if not np.all(np.isfinite(global_camera_transform)):
             print(
                 f"{Colors.YELLOW}Operation - Skipping publish of robot transform due to non-finite values{Colors.RESET}"
             )
-            self.non_finite_count += 1
-            if self.non_finite_count >= 3:
-                self.clear_position_cache()
-                print(
-                    f"{Colors.CYAN}Position cache cleared due to 3 consecutive non-finite values{Colors.RESET}"
-                )
             return None
 
-        if self.position_cache_enabled:
-            self.last_pose = global_camera_transform
-
-        # Reset counter on successful finite result
-        self.non_finite_count = 0
         return global_camera_transform


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Removes the PnP position cache entirely so each frame is solved independently from the current AprilTag detections.

## Changes
- `PnpLocalization` no longer stores prior poses or uses `useExtrinsicGuess`
- Removes jump-threshold retry / cache-clearing logic
- Drops `jump_threshold` and `position_cache_enabled` from the operation definition, WebUI config schema, default pipeline config, and docs
- Fixes `PipelineOverview.md` PnP example to use `camera_bus_id` instead of unsupported `camera_parameters_path`

## Notes
Existing saved pipelines that still pass `jump_threshold` or `position_cache_enabled` will need those keys removed, since they are no longer accepted constructor parameters.

## Testing
- `mypy` on changed PnP files: clean
- `pytest tests/test_operation_initialization.py tests/test_operation_runs.py`: 48 passed, 2 skipped
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7c55-4546-7fe0-8676-b2314c1f5d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7c55-4546-7fe0-8676-b2314c1f5d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior Changes**
  - Pose estimation now solves each frame independently using current AprilTag detections.
  - Removed pose caching, jump-threshold filtering, and related configuration options.
  - Invalid or non-finite pose results are rejected.

- **Documentation**
  - Updated configuration examples and parameter references.
  - Clarified pose-solving behavior and documented output limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->