### PR TITLE
Add read-only demo mode with multi-client SSE

### DIFF
--- a/docs/overviews/webui/API_DOCUMENTATION.md
+++ b/docs/overviews/webui/API_DOCUMENTATION.md
@@ -429,7 +429,7 @@ Or if not found:
 
 #### GET `/sse/stream`
 
-**Description:** Server-Sent Events stream for real-time updates
+**Description:** Server-Sent Events stream for real-time updates. Supports multiple concurrent browser clients; each connection receives a fan-out of the same events.
 **Response:** Event stream with real-time data
 **Content-Type:** `text/event-stream`
 **Events:**
@@ -445,6 +445,10 @@ Or if not found:
 **Status Codes:**
 
 - `200`: Success
+
+#### Demo mode
+
+When `demo_mode` is enabled (`general_conf.json` or `EAGLEEYE_DEMO_MODE=1`), mutating endpoints return `403` except `POST /get-operation-config-data-batch`, `POST /start-visualize/...`, and `POST /stop-visualize/...`.
 
 ## Server-Sent Events
 

--- a/docs/overviews/webui/API_ENDPOINTS_SUMMARY.md
+++ b/docs/overviews/webui/API_ENDPOINTS_SUMMARY.md
@@ -176,7 +176,13 @@ The EagleEye WebUI provides a comprehensive REST API and Server-Sent Events (SSE
 
 #### `GET /sse/stream`
 
-- **Purpose**: Server-Sent Events stream
+- **Purpose**: Server-Sent Events stream (multi-client fan-out)
 - **Response**: Event stream with real-time updates
 - **Events**: `heartbeat`, `update_robot_transform`, `update_detected_objects`
-- **Use**: Real-time data subscription
+- **Use**: Real-time data subscription for one or many concurrent viewers
+
+### Demo mode
+
+- Enable with `"demo_mode": true` in `general_conf.json` or `EAGLEEYE_DEMO_MODE=1`
+- Mutating endpoints return `403` (except visualize start/stop and operation config batch fetch)
+- Drop demo MP4s in `src/utils/sim_videos/` matching pipeline `camera_bus_id` values

--- a/docs/overviews/webui/BACKEND_OVERVIEW.md
+++ b/docs/overviews/webui/BACKEND_OVERVIEW.md
@@ -91,6 +91,13 @@ Handles 3D model compression and decompression for web delivery.
 
 ### Server-Sent Events (`GET /sse/stream`)
 - **Primary WebUI channel:** `EventSource` in the browser for heartbeats, `update_robot_transform`, `update_camera_pose`, `update_detected_objects`, `log_update`, `profiling_update`, `pipeline_operation_errors`, and related payloads.
+- **Multi-client:** Each browser connection gets its own SSE queue. Events are fan-out published to every connected subscriber so multiple viewers can share one live demo session.
+
+### Demo / read-only mode
+- Enabled by `"demo_mode": true` in `src/general_conf.json`, or by env `EAGLEEYE_DEMO_MODE=1` (env overrides config).
+- Mutating HTTP methods (`POST`/`PUT`/`DELETE`) return `403`, except ephemeral viewing helpers (`get_operation_config_data_batch`, `start_visualize`, `stop_visualize`).
+- Frontend hides save/edit controls and opens operation settings as view-only.
+- Simulated cameras come from `src/utils/sim_videos/*.mp4` (drop an MP4 named to match the pipeline `camera_bus_id`, then restart).
 
 ### Socket.IO (optional)
 - Flask-SocketIO runs the server; some tooling may attach a Socket.IO client (for example `profiling_update` when `globalThis.socket` is present).

--- a/docs/overviews/webui/WEBUI_OVERVIEW.md
+++ b/docs/overviews/webui/WEBUI_OVERVIEW.md
@@ -135,7 +135,7 @@ webui/
 - **Python**: Core application logic
 - **Flask**: Web framework
 - **SocketIO**: Primary real-time communication for bidirectional messaging
-- **Server-Sent Events (SSE)**: Fallback real-time communication (single-client support)
+- **Server-Sent Events (SSE)**: Real-time communication with multi-client fan-out (each browser keeps its own event queue)
 - **Flask-CORS**: Cross-origin resource sharing
 - **OpenCV**: Camera processing and streaming
 - **NumPy**: Numerical computations

--- a/src/general_conf.json
+++ b/src/general_conf.json
@@ -1,4 +1,5 @@
 {
     "network_table_address": "localhost",
-    "view_stream_downscale": 0.1
+    "view_stream_downscale": 0.1,
+    "demo_mode": true
 }

--- a/src/webui/html/tabs/pipeline_tab_content.html
+++ b/src/webui/html/tabs/pipeline_tab_content.html
@@ -18,7 +18,10 @@
                                 </h1>
                             </div>
                             <div class="flex items-center gap-4">
-                                <p class="text-[#ac8a2f] mt-1">
+                                <p
+                                    id="pipelineBuilderSubtitle"
+                                    class="text-[#ac8a2f] mt-1"
+                                >
                                     Drag operations to build your pipeline
                                 </p>
                             </div>

--- a/src/webui/js/demoMode.js
+++ b/src/webui/js/demoMode.js
@@ -1,0 +1,158 @@
+import { BACKEND_BASE_URL } from "./config.js";
+
+let demoModeEnabled = false;
+let demoModeResolved = false;
+/** @type {Promise<boolean>|null} */
+let demoModeLoadPromise = null;
+
+/**
+ * Apply demo-mode CSS class and banner to the document body.
+ *
+ * @param {boolean} enabled - Whether demo mode is active.
+ */
+function applyDemoModeDocumentState(enabled) {
+    document.body.classList.toggle("demo-mode", enabled);
+
+    let banner = document.getElementById("demo-mode-banner");
+    if (!enabled) {
+        banner?.remove();
+        return;
+    }
+
+    if (!banner) {
+        banner = document.createElement("div");
+        banner.id = "demo-mode-banner";
+        banner.className =
+            "fixed bottom-3 left-1/2 -translate-x-1/2 z-[120] px-4 py-2 rounded-md border border-[#f9c845]/60 bg-[#1b1b1b]/95 text-[#f9c845] text-sm font-semibold shadow-lg pointer-events-none";
+        banner.textContent = "Demo mode — view only (changes are not saved)";
+        document.body.appendChild(banner);
+    }
+}
+
+/**
+ * Disable common mutable controls across settings and pipeline chrome.
+ */
+function disableMutableControls() {
+    const controlIds = [
+        "saveSettingsBtn",
+        "restartBackendBtn",
+        "restartBackendButton",
+        "newPipelineButton",
+        "deletePipelineButton",
+        "undoButton",
+        "redoButton",
+        "pipelineJsonEditorButton",
+        "pipelineSettingsButton",
+    ];
+
+    for (const controlId of controlIds) {
+        const control = document.getElementById(controlId);
+        if (!control) {
+            continue;
+        }
+        control.setAttribute("disabled", "true");
+        control.classList.add("opacity-40", "cursor-not-allowed", "pointer-events-none");
+        control.classList.add("hidden");
+    }
+
+    const editableInputs = [
+        "robotAddressInput",
+        "viewStreamDownscaleInput",
+    ];
+    for (const inputId of editableInputs) {
+        const input = document.getElementById(inputId);
+        if (!input) {
+            continue;
+        }
+        input.setAttribute("readonly", "true");
+        input.setAttribute("disabled", "true");
+    }
+
+    const manageButtonSelectors = [
+        "#manageTestVideosBtn",
+        "#manageRobotFilesBtn",
+        "#manageFieldFilesBtn",
+        "#wifiConnectBtn",
+        "#wifiDisconnectBtn",
+        "#runSystemUpdateBtn",
+        "#testNotificationsBtn",
+    ];
+    for (const selector of manageButtonSelectors) {
+        const button = document.querySelector(selector);
+        if (!button) {
+            continue;
+        }
+        button.setAttribute("disabled", "true");
+        button.classList.add("opacity-40", "cursor-not-allowed", "pointer-events-none");
+    }
+
+    const operationsList = document.getElementById("operationsList");
+    if (operationsList) {
+        operationsList.classList.add("pointer-events-none", "opacity-60");
+        operationsList.setAttribute("aria-disabled", "true");
+    }
+
+    const pipelineSubtitle = document.getElementById("pipelineBuilderSubtitle");
+    if (pipelineSubtitle) {
+        pipelineSubtitle.textContent =
+            "View pipeline configuration (read-only demo)";
+    }
+}
+
+/**
+ * Load demo mode state from the backend general configuration.
+ *
+ * @returns {Promise<boolean>} Whether demo mode is enabled.
+ */
+export async function loadDemoMode() {
+    if (demoModeResolved) {
+        return demoModeEnabled;
+    }
+    if (demoModeLoadPromise) {
+        return demoModeLoadPromise;
+    }
+
+    demoModeLoadPromise = (async () => {
+        try {
+            const response = await fetch(`${BACKEND_BASE_URL}/get-general-conf`, {
+                method: "GET",
+                headers: { "Content-Type": "application/json" },
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const settings = await response.json();
+            demoModeEnabled = Boolean(settings?.demo_mode);
+        } catch (error) {
+            console.warn("Failed to load demo mode flag; assuming disabled", error);
+            demoModeEnabled = false;
+        }
+
+        demoModeResolved = true;
+        applyDemoModeDocumentState(demoModeEnabled);
+        if (demoModeEnabled) {
+            disableMutableControls();
+        }
+        return demoModeEnabled;
+    })();
+
+    return demoModeLoadPromise;
+}
+
+/**
+ * Return whether demo/read-only mode is currently active.
+ *
+ * @returns {boolean} True when the UI should be read-only.
+ */
+export function isDemoMode() {
+    return demoModeEnabled;
+}
+
+/**
+ * Wait until demo mode has been resolved from the backend.
+ *
+ * @returns {Promise<boolean>} Whether demo mode is enabled.
+ */
+export async function whenDemoModeReady() {
+    return loadDemoMode();
+}

--- a/src/webui/js/main.js
+++ b/src/webui/js/main.js
@@ -24,6 +24,7 @@ import {
     updateCameraPose,
 } from "./init3DView.js";
 import { BACKEND_BASE_URL } from "./config.js";
+import { loadDemoMode, isDemoMode } from "./demoMode.js";
 import {
     showSuccess,
     showWarning,
@@ -111,15 +112,20 @@ async function refreshPipelineCreator() {
 window.onload = async () => {
     const destroyTooltips = initializeTooltips();
 
+    await loadDemoMode();
     await populateFieldDropdown();
     setupSidebar();
     setupCameraFeedHandlers();
     initializeTerminalHandlers();
-    initializeTestVideoManager();
-    initializeAssetFileManager();
-    initializeNetworkManager();
-    initializeSystemUpdateManager();
-    saveSettings();
+    if (!isDemoMode()) {
+        initializeTestVideoManager();
+        initializeAssetFileManager();
+        initializeNetworkManager();
+        initializeSystemUpdateManager();
+        saveSettings();
+    } else {
+        console.log("Demo mode: skipping mutable settings managers");
+    }
 
     const systemStatusModule = createSystemStatusModule();
     const faviconLink = document.getElementById("favicon");

--- a/src/webui/js/pipeline/creator/dataApi.js
+++ b/src/webui/js/pipeline/creator/dataApi.js
@@ -1,9 +1,25 @@
 import { BACKEND_BASE_URL } from "../../config.js";
+import { isDemoMode } from "../../demoMode.js";
 import { showDanger } from "../../ui/notificationSystem.js";
 
 /**
  * Data access helpers for the pipeline creator UI.
  */
+
+/**
+ * Reject mutating pipeline API calls while demo mode is active.
+ *
+ * @param {string} actionLabel - Human-readable action name for logging.
+ * @returns {boolean} True when the caller should abort the mutation.
+ */
+function rejectDemoMutation(actionLabel) {
+    if (!isDemoMode()) {
+        return false;
+    }
+    console.warn(`Demo mode blocked pipeline mutation: ${actionLabel}`);
+    showDanger("Demo mode is read-only. Changes are not saved.");
+    return true;
+}
 
 /**
  * Convert a backend operation name into a title-cased display name.
@@ -189,6 +205,9 @@ export async function fetchPipelineConfigJson() {
  * @returns {Promise<object>} Backend response payload.
  */
 export async function savePipelineConfigJson(content, revision) {
+    if (rejectDemoMutation("savePipelineConfigJson")) {
+        throw new Error("Demo mode is read-only");
+    }
     const response = await fetch(`${BACKEND_BASE_URL}/pipeline-config/json`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -220,6 +239,9 @@ export async function savePipelineConfigJson(content, revision) {
  * @returns {Promise<object>} Backend response payload.
  */
 export async function savePipelineConfig(pipelineName, pipelineConfig) {
+    if (rejectDemoMutation("savePipelineConfig")) {
+        throw new Error("Demo mode is read-only");
+    }
     const response = await fetch(
         `${BACKEND_BASE_URL}/save-pipeline-config/${encodeURIComponent(pipelineName)}`,
         {
@@ -241,6 +263,9 @@ export async function savePipelineConfig(pipelineName, pipelineConfig) {
  * @returns {Promise<object>} Backend response payload.
  */
 export async function deletePipelineConfig(pipelineName) {
+    if (rejectDemoMutation("deletePipelineConfig")) {
+        throw new Error("Demo mode is read-only");
+    }
     const response = await fetch(
         `${BACKEND_BASE_URL}/delete-pipeline/${encodeURIComponent(pipelineName)}`,
         {
@@ -278,6 +303,9 @@ export async function fetchPipelineSettings(pipelineName) {
  * @returns {Promise<object>} Backend response payload.
  */
 export async function savePipelineSettings(pipelineName, settings) {
+    if (rejectDemoMutation("savePipelineSettings")) {
+        throw new Error("Demo mode is read-only");
+    }
     const response = await fetch(
         `${BACKEND_BASE_URL}/pipeline-settings/${encodeURIComponent(pipelineName)}`,
         {
@@ -328,6 +356,9 @@ export async function getRestartRequired() {
  * @returns {Promise<object>} Backend response payload.
  */
 export async function setRestartRequired(required) {
+    if (rejectDemoMutation("setRestartRequired")) {
+        throw new Error("Demo mode is read-only");
+    }
     const response = await fetch(`${BACKEND_BASE_URL}/set_restart_required`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -345,6 +376,9 @@ export async function setRestartRequired(required) {
  * @returns {Promise<object>} Backend response payload.
  */
 export async function restartBackend() {
+    if (rejectDemoMutation("restartBackend")) {
+        throw new Error("Demo mode is read-only");
+    }
     const response = await fetch(`${BACKEND_BASE_URL}/restart-backend`, {
         method: "POST",
     });

--- a/src/webui/js/pipeline/creator/flowchartController.js
+++ b/src/webui/js/pipeline/creator/flowchartController.js
@@ -3,6 +3,7 @@ import { FlowchartRenderer } from "../rendering.js";
 import { handleDragStart } from "../dragDrop.js";
 import { confirmDialog } from "../../ui/confirmationDialog.js";
 import { showDanger, showWarning } from "../../ui/notificationSystem.js";
+import { isDemoMode } from "../../demoMode.js";
 import { pipelineStore } from "../PipelineStore.js";
 import { creatorContext } from "./context.js";
 import { getDeviceInputNodes, getSelectedPipeline } from "./stateHelpers.js";
@@ -22,6 +23,10 @@ import { updateRestartIndicator } from "./restartController.js";
  * @returns {any} The underlying drag-start handler result.
  */
 function handleDragStartWithLogging(event, item, fromIndex = null, collection = null) {
+    if (isDemoMode()) {
+        event.preventDefault();
+        return;
+    }
     console.log("[PIPELINE] Drag start initiated", {
         draggedElement: event.target,
         itemInstanceId: item?.instanceId || null,
@@ -203,6 +208,7 @@ function initFlowchartRenderer({ openOperationSettings, updateRunButton, removeF
         gridSpacing: 20,
         nodeSpacingX: 300,
         nodeSpacingY: 150,
+        readOnly: isDemoMode(),
         openOperationSettings,
         updateRunButton,
         removeFromPipeline,

--- a/src/webui/js/pipeline/creator/historyController.js
+++ b/src/webui/js/pipeline/creator/historyController.js
@@ -1,9 +1,13 @@
 import { pipelineHistory } from "../pipelineHistory.js";
+import { isDemoMode } from "../../demoMode.js";
 
 /**
  * History controller for wiring pipeline undo/redo state to UI controls and keyboard shortcuts.
  */
 export function initializePipelineHistory(pipelineStore, callbacks) {
+    if (isDemoMode()) {
+        return;
+    }
     pipelineHistory.init(pipelineStore, callbacks);
 }
 
@@ -11,6 +15,9 @@ export function initializePipelineHistory(pipelineStore, callbacks) {
  * Bind the undo and redo buttons to the shared pipeline history instance.
  */
 export function bindHistoryButtons(undoButton, redoButton) {
+    if (isDemoMode()) {
+        return;
+    }
     pipelineHistory.setButtons(undoButton, redoButton);
 }
 
@@ -18,6 +25,9 @@ export function bindHistoryButtons(undoButton, redoButton) {
  * Attach global keyboard shortcuts for pipeline history actions.
  */
 export function attachHistoryKeyboardShortcuts() {
+    if (isDemoMode()) {
+        return;
+    }
     document.addEventListener("keydown", (event) => {
         const pipelineView = document.getElementById("view-pipeline");
         if (pipelineView?.classList.contains("hidden")) return;

--- a/src/webui/js/pipeline/creator/pipelineActions.js
+++ b/src/webui/js/pipeline/creator/pipelineActions.js
@@ -7,6 +7,7 @@ import {
     showSuccess,
     showWarning,
 } from "../../ui/notificationSystem.js";
+import { isDemoMode } from "../../demoMode.js";
 import { creatorContext } from "./context.js";
 import {
     getOperations,
@@ -260,6 +261,10 @@ function deviceInputsShareComponent(operations) {
  * @param {{showNotification?: boolean, requiresRestart?: boolean}} [options={}] - Save options.
  */
 async function autoSavePipelineImpl(options = {}) {
+    if (isDemoMode()) {
+        console.log("Demo mode: skipping pipeline auto-save");
+        return null;
+    }
     const selectedPipeline = getSelectedPipeline();
     if (!selectedPipeline) {
         console.log("No pipeline selected, skipping auto-save");
@@ -329,6 +334,10 @@ async function createNewPipeline({
     updateDeleteButtonVisibility,
     autoSavePipeline,
 }) {
+    if (isDemoMode()) {
+        showDanger("Demo mode is read-only. Creating pipelines is disabled.");
+        return;
+    }
     const newPipelineName = prompt("Enter a name for the new pipeline:");
     if (!newPipelineName || newPipelineName.trim() === "") return;
     const pipelineFileName = newPipelineName.trim().replaceAll(/\s+/g, "_");
@@ -395,6 +404,10 @@ async function deleteCurrentPipeline({
     updateDeleteButtonVisibility,
     updateRunButton,
 }) {
+    if (isDemoMode()) {
+        showDanger("Demo mode is read-only. Deleting pipelines is disabled.");
+        return;
+    }
     const selectedPipeline = getSelectedPipeline();
     if (!selectedPipeline) {
         alert("No pipeline selected to delete.");

--- a/src/webui/js/pipeline/creator/settingsController.js
+++ b/src/webui/js/pipeline/creator/settingsController.js
@@ -1,6 +1,8 @@
 /**
  * Controller for opening and saving operation settings popups.
  */
+import { isDemoMode } from "../../demoMode.js";
+
 export function createOperationSettingsController({
     pipelineStore,
     updatePipelineCameraNote,
@@ -24,6 +26,7 @@ export function createOperationSettingsController({
         const operationUuid = settingsItem.uuid || settingsItem.instanceId;
         const isSecondary = settingsItem.isSecondary || false;
         const initialValues = { ...(settingsItem.config || {}) };
+        const readOnly = isDemoMode();
 
         if (!settingsItem.originalConfig) {
             settingsItem.originalConfig = { ...initialValues };
@@ -35,6 +38,10 @@ export function createOperationSettingsController({
          * @param {object} values - Settings values submitted by the popup.
          */
         const onSave = (values) => {
+            if (isDemoMode()) {
+                console.log("Demo mode: ignoring settings save");
+                return;
+            }
             console.log("Saved settings for", settingsItem, values);
             const isAutoSaveFlag = values._isAutoSave;
             const requiresRestart = values._requiresRestart;
@@ -97,6 +104,7 @@ export function createOperationSettingsController({
                     isSecondary,
                     initialValues,
                     onSave,
+                    readOnly,
                 });
             } catch (err) {
                 console.error("Failed to open SettingsPopup:", err);

--- a/src/webui/js/pipeline/flowchartNode.js
+++ b/src/webui/js/pipeline/flowchartNode.js
@@ -41,6 +41,7 @@ export class FlowchartNode {
         this.onRemoveClick = options.onRemoveClick || null;
         this.onPortHover = options.onPortHover || null;
         this.onPortClick = options.onPortClick || null;
+        this.readOnly = Boolean(options.readOnly);
 
         this.isDragging = false;
         this.isHovered = false;
@@ -1180,22 +1181,26 @@ export class FlowchartNode {
         }
 
         if (removeBtn) {
-            removeBtn.addEventListener("mouseenter", () => {
-                removeBtn.style.backgroundColor = "#404040";
-                const img = removeBtn.querySelector("img");
-                if (img) img.style.filter = "none";
-            });
-            removeBtn.addEventListener("mouseleave", () => {
-                removeBtn.style.backgroundColor = "transparent";
-                const img = removeBtn.querySelector("img");
-                if (img) img.style.filter = "grayscale(100%)";
-            });
-            removeBtn.addEventListener("click", (e) => {
-                e.stopPropagation();
-                if (this.onRemoveClick) {
-                    this.onRemoveClick(this.instanceId);
-                }
-            });
+            if (this.readOnly) {
+                removeBtn.classList.add("hidden");
+            } else {
+                removeBtn.addEventListener("mouseenter", () => {
+                    removeBtn.style.backgroundColor = "#404040";
+                    const img = removeBtn.querySelector("img");
+                    if (img) img.style.filter = "none";
+                });
+                removeBtn.addEventListener("mouseleave", () => {
+                    removeBtn.style.backgroundColor = "transparent";
+                    const img = removeBtn.querySelector("img");
+                    if (img) img.style.filter = "grayscale(100%)";
+                });
+                removeBtn.addEventListener("click", (e) => {
+                    e.stopPropagation();
+                    if (this.onRemoveClick) {
+                        this.onRemoveClick(this.instanceId);
+                    }
+                });
+            }
         }
     }
 
@@ -1216,6 +1221,7 @@ export class FlowchartNode {
     handleDragStart(event) {
         // Only handle left mouse button
         if (event.button !== 0) return;
+        if (this.readOnly) return;
 
         this.isDragging = true;
         // Find the canvas to get scale and translate

--- a/src/webui/js/pipeline/rendering.js
+++ b/src/webui/js/pipeline/rendering.js
@@ -327,6 +327,7 @@ export class FlowchartRenderer {
             onPipelineChange: options.onPipelineChange || (() => {}),
             autoSavePipeline: options.autoSavePipeline || (() => {}),
         };
+        this.readOnly = Boolean(options.readOnly);
 
         this.gridSpacing = options.gridSpacing || 20;
         this.nodeSpacingX = options.nodeSpacingX || 300;
@@ -514,6 +515,9 @@ export class FlowchartRenderer {
      * @param {DragEvent} e Drop event.
      */
     async handleDrop(e) {
+        if (this.readOnly) {
+            return;
+        }
         let dropData = null;
 
         try {
@@ -796,13 +800,18 @@ export class FlowchartRenderer {
     async createNode(item) {
         const node = new FlowchartNode(item, {
             gridSpacing: this.gridSpacing,
+            readOnly: this.readOnly,
             onDragStart: this.handleNodeDragStart.bind(this),
             onDragEnd: this.handleNodeDragEnd.bind(this),
             onPositionChange: this.handleNodePositionChange.bind(this),
             onSettingsClick: this.callbacks.openOperationSettings,
-            onRemoveClick: this.handleNodeRemove.bind(this),
+            onRemoveClick: this.readOnly
+                ? null
+                : this.handleNodeRemove.bind(this),
             onPortHover: this.handlePortHover.bind(this),
-            onPortClick: this.handlePortClick.bind(this),
+            onPortClick: this.readOnly
+                ? null
+                : this.handlePortClick.bind(this),
         });
 
         const element = await node.createElement();
@@ -880,6 +889,10 @@ export class FlowchartRenderer {
      * @param {{x:number,y:number}} position Final position.
      */
     handleNodeDragEnd(node, position) {
+        if (this.readOnly) {
+            node.element.style.zIndex = "10";
+            return;
+        }
         node.element.style.zIndex = "10";
 
         const item = this.pipeline.find(
@@ -1026,6 +1039,9 @@ export class FlowchartRenderer {
      * @param {MouseEvent} event Click event.
      */
     handlePortClick(node, portName, portType, event) {
+        if (this.readOnly) {
+            return;
+        }
         if (portType === "output") {
             // Check for existing connections from this output port
             const existingConnections = this.connections.getConnectionsForPort(
@@ -1432,6 +1448,9 @@ export class FlowchartRenderer {
      * @param {string} instanceId Node instance id.
      */
     handleNodeRemove(instanceId) {
+        if (this.readOnly) {
+            return;
+        }
         this.callbacks.removeFromPipeline(instanceId);
     }
 

--- a/src/webui/js/pipeline/settingsPopup.js
+++ b/src/webui/js/pipeline/settingsPopup.js
@@ -1241,11 +1241,22 @@ export function registerSettingsPopup() {
         originalValues,
         onSave,
         operationName = null,
+        readOnly = false,
     ) {
         modalBody.innerHTML = "";
         const fields = [];
 
         renderPortGroupsSummary(modalBody, config);
+
+        if (readOnly) {
+            modalBody.appendChild(
+                createElement("div", {
+                    className:
+                        "mb-3 rounded-md border border-[#f9c845]/40 bg-[#2a2a2a] px-3 py-2 text-xs text-[#f9c845]",
+                    text: "Demo mode: settings are view-only and cannot be changed.",
+                }),
+            );
+        }
 
         const params = config?.parameters || {};
         // Object.keys() preserves insertion order in ES2015+
@@ -1263,14 +1274,24 @@ export function registerSettingsPopup() {
             modalBody.appendChild(field.wrapper);
         });
 
-        // Set up auto-save event listeners
-        setupAutoSaveListeners(
-            modalBody,
-            fields,
-            originalValues,
-            onSave,
-            config,
-        );
+        if (readOnly) {
+            modalBody
+                .querySelectorAll("input, select, textarea, button")
+                .forEach((element) => {
+                    element.setAttribute("disabled", "true");
+                    if (element.tagName === "BUTTON") {
+                        element.classList.add("hidden");
+                    }
+                });
+        } else {
+            setupAutoSaveListeners(
+                modalBody,
+                fields,
+                originalValues,
+                onSave,
+                config,
+            );
+        }
 
         return () => {
             const result = {};
@@ -1648,11 +1669,13 @@ export function registerSettingsPopup() {
         isSecondary,
         initialValues,
         onSave,
+        readOnly = false,
     }) {
         console.log("[SETTINGS] Opening settings popup", {
             operationName,
             isSecondary,
             title,
+            readOnly,
             initialValuesKeys: Object.keys(initialValues || {}),
             timestamp: new Date().toISOString(),
         });
@@ -1823,6 +1846,7 @@ export function registerSettingsPopup() {
                         originalValues,
                         onSave,
                         operationName,
+                        readOnly,
                     );
 
                     const saveBtn = modal.querySelector("[data-action='save']");
@@ -1831,36 +1855,46 @@ export function registerSettingsPopup() {
                     );
 
                     if (saveBtn) {
-                        saveBtn.onclick = () => {
-                            const values = getValues();
-                            console.log(
-                                "[SETTINGS] Saving operation settings",
-                                {
-                                    operationName,
-                                    isSecondary,
-                                    savedValues: values,
-                                    timestamp: new Date().toISOString(),
-                                },
-                            );
-                            if (typeof onSave === "function") onSave(values);
-                            console.log(
-                                "[SETTINGS] Settings saved, closing popup",
-                                {
-                                    operationName,
-                                    timestamp: new Date().toISOString(),
-                                },
-                            );
-                            close();
-                        };
+                        if (readOnly) {
+                            saveBtn.classList.add("hidden");
+                            saveBtn.onclick = null;
+                        } else {
+                            saveBtn.onclick = () => {
+                                const values = getValues();
+                                console.log(
+                                    "[SETTINGS] Saving operation settings",
+                                    {
+                                        operationName,
+                                        isSecondary,
+                                        savedValues: values,
+                                        timestamp: new Date().toISOString(),
+                                    },
+                                );
+                                if (typeof onSave === "function") onSave(values);
+                                console.log(
+                                    "[SETTINGS] Settings saved, closing popup",
+                                    {
+                                        operationName,
+                                        timestamp: new Date().toISOString(),
+                                    },
+                                );
+                                close();
+                            };
+                        }
                     }
-                    if (cancelBtn) cancelBtn.onclick = () => close();
+                    if (cancelBtn) {
+                        cancelBtn.textContent = readOnly ? "Close" : "Cancel";
+                        cancelBtn.onclick = () => close();
+                    }
                 }
 
-                renderLineProfilingSection(
-                    body,
-                    selectedPipelineName,
-                    operationUuid,
-                );
+                if (!readOnly) {
+                    renderLineProfilingSection(
+                        body,
+                        selectedPipelineName,
+                        operationUuid,
+                    );
+                }
 
                 // Start visualization now that modal content is ready - wait for it to complete
                 await startVisIfReady();

--- a/src/webui/js/settings/settingsHandler.js
+++ b/src/webui/js/settings/settingsHandler.js
@@ -1,4 +1,5 @@
 import { BACKEND_BASE_URL } from "../config.js";
+import { isDemoMode } from "../demoMode.js";
 import { setNetworkTablesConnected } from "../ui/connectionStatus.js";
 import { showDanger, showSuccess, showWarning } from "../ui/notificationSystem.js";
 
@@ -123,6 +124,11 @@ export async function loadSettings() {
 export function saveSettings() {
     const saveSettingsBtn = document.getElementById("saveSettingsBtn");
     if (!saveSettingsBtn) {
+        return;
+    }
+    if (isDemoMode()) {
+        saveSettingsBtn.setAttribute("disabled", "true");
+        saveSettingsBtn.classList.add("hidden");
         return;
     }
 

--- a/src/webui/js/ui/sidebar.js
+++ b/src/webui/js/ui/sidebar.js
@@ -8,11 +8,9 @@ import {
 } from "../feeds/cameraFeedHandlers.js";
 import { initPipelineCreator } from "../pipeline/pipelineCreator.js";
 import { refreshLogMessages } from "../settings/terminalHandler.js";
-import {
-    initCameraConfigUtils,
-    refreshCameraConfigUtils,
-} from "../utils/cameraConfigUtils.js";
+import { initCameraConfigUtils, refreshCameraConfigUtils } from "../utils/cameraConfigUtils.js";
 import { getSelectedFieldModel } from "../dropdown/fieldDropdown.js";
+import { isDemoMode } from "../demoMode.js";
 
 const VIEWS = {
     THREE_D: "view-3d",
@@ -158,8 +156,10 @@ class ViewManager {
                 break;
             case VIEWS.UTILS:
                 pauseCameraFeeds();
-                initCameraConfigUtils();
-                refreshCameraConfigUtils();
+                if (!isDemoMode()) {
+                    initCameraConfigUtils();
+                    refreshCameraConfigUtils();
+                }
                 break;
             default:
                 pauseCameraFeeds();

--- a/src/webui/web_server.py
+++ b/src/webui/web_server.py
@@ -40,6 +40,7 @@ from src.webui.web_server_utils.constants import (
     CORS_ALLOWED_ORIGINS,
     DEFAULT_GENERAL_CONF,
     DEFAULT_VIEW_STREAM_DOWNSCALE,
+    DEMO_MODE_MUTATION_ALLOWLIST,
     GENERAL_CONF_PATH,  # noqa: F401 (for tests)
     PIPELINE_NOT_FOUND_MESSAGE,  # noqa: F401 (for tests)
     PROFILING_PUBLISH_INTERVAL_SECONDS,
@@ -50,6 +51,7 @@ from src.webui.web_server_utils.constants import (
     WEB_SERVER_HOST,
     WEB_SERVER_PORT,
     VIEW_STREAM_DOWNSCALE_KEY,
+    resolve_demo_mode,
 )
 
 # Re-export for external callers (main_backend.py, tests)
@@ -199,9 +201,15 @@ class EagleEyeInterface(
 
         logging.getLogger("werkzeug").addFilter(_SuppressHandshakeErrors())
 
-        # Simplified single-client SSE: one queue and a lock to guard it.
-        self._sse_queue: queue.Queue | None = None
+        # Multi-client SSE: each connected browser gets its own queue.
+        self._sse_queues: set[queue.Queue] = set()
         self._sse_queue_lock = threading.Lock()
+        try:
+            self._demo_mode_enabled = resolve_demo_mode(self._read_general_conf())
+        except Exception:
+            self._demo_mode_enabled = resolve_demo_mode()
+        if self._demo_mode_enabled:
+            self.log("Demo mode enabled: mutating API requests will be rejected")
         self._pipeline_error_lock = threading.Lock()
         self._pipeline_error_cache: dict[str, dict[str, Any]] = {}
         self._pipeline_error_dirty_pipelines: set[str] = set()
@@ -223,6 +231,7 @@ class EagleEyeInterface(
 
         self._register_response_optimizations()
         self._register_error_handlers()
+        self._register_demo_mode_guard()
         self._register_routes()
 
         if dev_mode:
@@ -255,6 +264,37 @@ class EagleEyeInterface(
                 return e
             self.log(f"Error: {traceback.format_exc()}")
             return {"message": "Internal server error"}, 500
+
+    def _is_demo_mode_enabled(self) -> bool:
+        """Return whether demo/read-only mode is currently active.
+
+        Returns:
+            True when mutating requests should be blocked.
+        """
+        try:
+            return resolve_demo_mode(self._read_general_conf())
+        except Exception:
+            return bool(self._demo_mode_enabled)
+
+    def _register_demo_mode_guard(self) -> None:
+        """Reject mutating HTTP requests while demo/read-only mode is enabled."""
+
+        @self.app.before_request
+        def _block_mutations_in_demo_mode():
+            if request.method in {"GET", "HEAD", "OPTIONS"}:
+                return None
+            if not self._is_demo_mode_enabled():
+                return None
+            endpoint_name = request.endpoint or ""
+            if endpoint_name in DEMO_MODE_MUTATION_ALLOWLIST:
+                return None
+            return (
+                {
+                    "error": "Demo mode is read-only. Configuration changes are disabled.",
+                    "demo_mode": True,
+                },
+                403,
+            )
 
     def _register_response_optimizations(self) -> None:
         """Register low-bandwidth response optimizations for WebUI clients."""
@@ -809,14 +849,43 @@ class EagleEyeInterface(
         """
         return f"event: {event}\ndata: {data}\n\n".encode()
 
+    def _enqueue_sse_message(self, client_queue: queue.Queue, msg: bytes, event_name: str) -> None:
+        """Enqueue an SSE payload for one client, dropping the oldest item if full.
+
+        Args:
+            client_queue: Per-client SSE queue.
+            msg: Formatted SSE message bytes.
+            event_name: Event name used for diagnostic logging.
+        """
+        try:
+            client_queue.put_nowait(msg)
+        except queue.Full:
+            try:
+                client_queue.get_nowait()
+                client_queue.put_nowait(msg)
+                self.log(
+                    f"SSE queue full, dropped oldest event to add {event_name}"
+                )
+            except queue.Empty:
+                self.log(
+                    f"SSE queue unexpectedly empty when trying to drop oldest for {event_name}"
+                )
+            except queue.Full:
+                self.log(
+                    f"SSE queue still full after dropping oldest, dropping {event_name} event"
+                )
+        except Exception as error:
+            self.log(f"SSE publish error for {event_name}: {error}")
+
     def _sse_stream(self) -> Generator[bytes, Any, Any]:
+        """Yield SSE messages for one connected client.
+
+        Each browser connection gets an independent queue so multiple viewers
+        can receive the same live updates concurrently.
         """
-        Generator that yields SSE messages for a single client using a queue.
-        """
-        q: queue.Queue = queue.Queue(maxsize=100)
-        # assume single client: set queue, replacing any existing queue
+        client_queue: queue.Queue = queue.Queue(maxsize=100)
         with self._sse_queue_lock:
-            self._sse_queue = q
+            self._sse_queues.add(client_queue)
 
         with self._pipeline_error_lock:
             self._pipeline_error_dirty_pipelines.update(
@@ -828,7 +897,7 @@ class EagleEyeInterface(
         try:
             while True:
                 try:
-                    msg = q.get(timeout=1.0)
+                    msg = client_queue.get(timeout=1.0)
                     yield msg
                 except queue.Empty:
                     yield b": keepalive\n\n"
@@ -837,8 +906,7 @@ class EagleEyeInterface(
             pass
         finally:
             with self._sse_queue_lock:
-                if self._sse_queue is q:
-                    self._sse_queue = None
+                self._sse_queues.discard(client_queue)
 
     def _publish_event(self, event_name: str, data: object) -> None:
         """
@@ -857,27 +925,9 @@ class EagleEyeInterface(
             return
         msg = self._format_sse(event_name, payload)
         with self._sse_queue_lock:
-            q = self._sse_queue
-        if q is not None:
-            try:
-                q.put_nowait(msg)
-            except queue.Full:
-                try:
-                    q.get_nowait()
-                    q.put_nowait(msg)
-                    self.log(
-                        f"SSE queue full, dropped oldest event to add {event_name}"
-                    )
-                except queue.Empty:
-                    self.log(
-                        f"SSE queue unexpectedly empty when trying to drop oldest for {event_name}"
-                    )
-                except queue.Full:
-                    self.log(
-                        f"SSE queue still full after dropping oldest, dropping {event_name} event"
-                    )
-            except Exception as e:
-                self.log(f"SSE publish error for {event_name}: {e}")
+            subscriber_queues = list(self._sse_queues)
+        for client_queue in subscriber_queues:
+            self._enqueue_sse_message(client_queue, msg, event_name)
 
     def _sse_heartbeat_loop(self) -> None:
         """

--- a/src/webui/web_server_utils/constants.py
+++ b/src/webui/web_server_utils/constants.py
@@ -42,6 +42,8 @@ DEFAULT_ASSET_SCALE = 1.0
 DEFAULT_ASSET_ROTATION_OFFSET = {"x": 0.0, "y": 0.0, "z": 0.0}
 GENERAL_CONF_PATH = Path(SRC_DIR) / "general_conf.json"
 VIEW_STREAM_DOWNSCALE_KEY = "view_stream_downscale"
+DEMO_MODE_KEY = "demo_mode"
+DEMO_MODE_ENV_VAR = "EAGLEEYE_DEMO_MODE"
 DEFAULT_VIEW_STREAM_DOWNSCALE = 0.5
 MIN_VIEW_STREAM_DOWNSCALE = 0.1
 MAX_VIEW_STREAM_DOWNSCALE = 1.0
@@ -49,4 +51,35 @@ VIEW_STREAM_JPEG_QUALITY = 70
 DEFAULT_GENERAL_CONF: dict[str, Any] = {
     "network_table_address": "0.0.0.0",
     VIEW_STREAM_DOWNSCALE_KEY: DEFAULT_VIEW_STREAM_DOWNSCALE,
+    DEMO_MODE_KEY: False,
 }
+DEMO_MODE_MUTATION_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "get_operation_config_data_batch",
+        "start_visualize",
+        "stop_visualize",
+    }
+)
+
+
+def resolve_demo_mode(config: dict[str, Any] | None = None) -> bool:
+    """Resolve whether demo/read-only mode is enabled.
+
+    Environment variable ``EAGLEEYE_DEMO_MODE`` overrides config when set to a
+    recognized truthy/falsey value. Otherwise ``demo_mode`` from general config
+    is used.
+
+    Args:
+        config: Optional general configuration dictionary.
+
+    Returns:
+        True when the UI and mutating APIs should run in read-only demo mode.
+    """
+    env_value = os.environ.get(DEMO_MODE_ENV_VAR, "").strip().lower()
+    if env_value in {"1", "true", "yes", "on"}:
+        return True
+    if env_value in {"0", "false", "no", "off"}:
+        return False
+    if isinstance(config, dict):
+        return bool(config.get(DEMO_MODE_KEY, False))
+    return bool(DEFAULT_GENERAL_CONF.get(DEMO_MODE_KEY, False))

--- a/src/webui/web_server_utils/system_monitor_mixin.py
+++ b/src/webui/web_server_utils/system_monitor_mixin.py
@@ -14,9 +14,11 @@ from src.utils.colors import Colors
 from src.webui.web_server_utils.constants import (
     DEFAULT_GENERAL_CONF,
     DEFAULT_VIEW_STREAM_DOWNSCALE,
+    DEMO_MODE_KEY,
     MAX_VIEW_STREAM_DOWNSCALE,
     MIN_VIEW_STREAM_DOWNSCALE,
     VIEW_STREAM_DOWNSCALE_KEY,
+    resolve_demo_mode,
 )
 
 
@@ -549,7 +551,9 @@ class SystemMonitorMixin:
         Get the general configuration.
         """
         try:
-            return self._read_general_conf(), 200
+            config = self._read_general_conf()
+            config[DEMO_MODE_KEY] = resolve_demo_mode(config)
+            return config, 200
         except Exception as e:
             return {"error": str(e)}, 500
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a deployable **read-only demo mode** so multiple people can connect to the same live EagleEye UI without changing config. Also fixes SSE so it fans out to every connected browser (it previously replaced the single shared queue on each new connection).

## What changed

### Multi-client realtime
- `/sse/stream` now gives each client its own queue and publishes events to all subscribers.
- MJPEG camera feeds were already per-connection; no change needed there.

### Demo / read-only mode
- Enabled by default on this branch via `"demo_mode": true` in `src/general_conf.json`.
- Override with env: `EAGLEEYE_DEMO_MODE=1` (force on) or `EAGLEEYE_DEMO_MODE=0` (force off).
- Backend rejects mutating `POST`/`PUT`/`DELETE` with `403`, except:
  - `POST /get-operation-config-data-batch` (read schemas)
  - `POST /start-visualize/...` and `POST /stop-visualize/...` (ephemeral live view)
- Frontend shows a “Demo mode — view only” banner, hides save/edit controls, blocks pipeline graph edits, and opens operation settings as view-only.

### Simulated input (ready for your video)
- Existing `src/utils/sim_videos/*.mp4` path is used unchanged.
- Drop an MP4 whose filename stem matches the pipeline `camera_bus_id` (default config expects `basic_test.mp4` → bus id `basic_test`), then restart the backend.

## How to deploy / run

```bash
# demo_mode is already true in general_conf.json on this branch
PYTHONPATH=/workspace uv run python src/main_backend.py
# WebUI: http://localhost:5001/
```

Optional: place `src/utils/sim_videos/basic_test.mp4` before starting so the default pipeline has a live feed.

## Testing
- `pytest tests/test_web_server_runtime.py tests/test_granular_profiling.py tests/test_test_video_management.py` — passed
- Smoke-tested multi-client SSE fan-out and demo-mode `403` guard
- `npm run build` — succeeded (static assets are gitignored / built at startup)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f806a-8e6d-7cc8-8e49-aeb32fae1d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f806a-8e6d-7cc8-8e49-aeb32fae1d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

